### PR TITLE
Remove the V1 suffix from the cred def

### DIFF
--- a/anoncreds/src/data_types/anoncreds/cred_def.rs
+++ b/anoncreds/src/data_types/anoncreds/cred_def.rs
@@ -33,15 +33,7 @@ pub struct CredentialDefinitionData {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(tag = "ver")]
-pub enum CredentialDefinition {
-    #[serde(rename = "1.0")]
-    CredentialDefinitionV1(CredentialDefinitionV1),
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CredentialDefinitionV1 {
+pub struct CredentialDefinition {
     pub schema_id: SchemaId,
     #[serde(rename = "type")]
     pub signature_type: SignatureType,
@@ -49,7 +41,7 @@ pub struct CredentialDefinitionV1 {
     pub value: CredentialDefinitionData,
 }
 
-impl CredentialDefinitionV1 {
+impl CredentialDefinition {
     pub fn get_public_key(&self) -> Result<ursa::cl::CredentialPublicKey, ConversionError> {
         let key = ursa::cl::CredentialPublicKey::build_from_parts(
             &self.value.primary,
@@ -60,7 +52,7 @@ impl CredentialDefinitionV1 {
     }
 }
 
-impl Validatable for CredentialDefinitionV1 {
+impl Validatable for CredentialDefinition {
     fn validate(&self) -> Result<(), ValidationError> {
         self.schema_id.validate()
     }

--- a/anoncreds/src/ffi/cred_def.rs
+++ b/anoncreds/src/ffi/cred_def.rs
@@ -1,14 +1,14 @@
-use std::ffi::c_char;
 use std::str::FromStr;
 
-use ffi_support::{rust_string_to_c, FfiStr};
+use ffi_support::FfiStr;
 
 use super::error::{catch_error, ErrorCode};
 use super::object::ObjectHandle;
+use crate::data_types::anoncreds::cred_def::CredentialDefinition;
 use crate::services::{
     issuer::create_credential_definition,
     types::{
-        CredentialDefinition, CredentialDefinitionConfig, CredentialDefinitionPrivate,
+        CredentialDefinitionConfig, CredentialDefinitionPrivate,
         CredentialKeyCorrectnessProof as KeyCorrectnessProof, SignatureType,
     },
 };
@@ -55,29 +55,6 @@ pub extern "C" fn anoncreds_create_credential_definition(
             *cred_def_pvt_p = cred_def_pvt;
             *key_proof_p = key_proof;
         }
-        Ok(())
-    })
-}
-
-#[no_mangle]
-pub extern "C" fn anoncreds_credential_definition_get_attribute(
-    handle: ObjectHandle,
-    name: FfiStr,
-    result_p: *mut *const c_char,
-) -> ErrorCode {
-    catch_error(|| {
-        check_useful_c_ptr!(result_p);
-        let cred_def = handle.load()?;
-        let cred_def = cred_def.cast_ref::<CredentialDefinition>()?;
-        let val = match name.as_opt_str().unwrap_or_default() {
-            "schema_id" => match cred_def {
-                CredentialDefinition::CredentialDefinitionV1(cred_def) => {
-                    cred_def.schema_id.to_owned()
-                }
-            },
-            s => return Err(err_msg!("Unsupported attribute: {}", s)),
-        };
-        unsafe { *result_p = rust_string_to_c(val) };
         Ok(())
     })
 }

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use super::types::*;
 use crate::data_types::anoncreds::{
-    cred_def::CredentialDefinitionId,
+    cred_def::{CredentialDefinition, CredentialDefinitionId},
     credential::AttributeValues,
     pres_request::{PresentationRequestPayload, RequestedAttributeInfo, RequestedPredicateInfo},
     presentation::{
@@ -40,7 +40,6 @@ pub fn create_credential_request(
         credential_offer
     );
 
-    let CredentialDefinition::CredentialDefinitionV1(cred_def) = cred_def;
     let credential_pub_key = CredentialPublicKey::build_from_parts(
         &cred_def.value.primary,
         cred_def.value.revocation.as_ref(),
@@ -93,7 +92,6 @@ pub fn process_credential(
     trace!("process_credential >>> credential: {:?}, cred_request_metadata: {:?}, master_secret: {:?}, cred_def: {:?}, rev_reg_def: {:?}",
             credential, cred_request_metadata, secret!(&master_secret), cred_def, rev_reg_def);
 
-    let CredentialDefinition::CredentialDefinitionV1(cred_def) = cred_def;
     let credential_pub_key = CredentialPublicKey::build_from_parts(
         &cred_def.value.primary,
         cred_def.value.revocation.as_ref(),
@@ -179,7 +177,6 @@ pub fn create_presentation(
             )
         })?;
 
-        let CredentialDefinition::CredentialDefinitionV1(cred_def) = cred_def;
         let credential_pub_key = CredentialPublicKey::build_from_parts(
             &cred_def.value.primary,
             cred_def.value.revocation.as_ref(),

--- a/anoncreds/src/services/types.rs
+++ b/anoncreds/src/services/types.rs
@@ -2,10 +2,7 @@ use std::collections::HashSet;
 
 use super::tails::TailsReader;
 pub use crate::data_types::anoncreds::{
-    cred_def::{
-        CredentialDefinition, CredentialDefinitionPrivate, CredentialKeyCorrectnessProof,
-        SignatureType,
-    },
+    cred_def::{CredentialDefinitionPrivate, CredentialKeyCorrectnessProof, SignatureType},
     cred_offer::CredentialOffer,
     cred_request::{CredentialRequest, CredentialRequestMetadata},
     credential::{AttributeValues, Credential, CredentialValues},

--- a/anoncreds/src/services/verifier.rs
+++ b/anoncreds/src/services/verifier.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 
 use super::helpers::*;
 use super::types::*;
+use crate::data_types::anoncreds::cred_def::CredentialDefinition;
 use crate::data_types::anoncreds::cred_def::CredentialDefinitionId;
 use crate::data_types::anoncreds::rev_reg::RevocationRegistryId;
 use crate::data_types::anoncreds::rev_reg_def::RevocationRegistryDefinitionId;
@@ -89,13 +90,12 @@ pub fn verify_presentation(
             .ok_or_else(|| err_msg!("Schema not provided for ID: {:?}", identifier.schema_id))?;
 
         let cred_def_id = CredentialDefinitionId::new(identifier.cred_def_id.clone())?;
-        let CredentialDefinition::CredentialDefinitionV1(cred_def) =
-            cred_defs.get(&cred_def_id).ok_or_else(|| {
-                err_msg!(
-                    "Credential Definition not provided for ID: {:?}",
-                    identifier.cred_def_id
-                )
-            })?;
+        let cred_def = cred_defs.get(&cred_def_id).ok_or_else(|| {
+            err_msg!(
+                "Credential Definition not provided for ID: {:?}",
+                identifier.cred_def_id
+            )
+        })?;
 
         let (rev_reg_def, rev_reg) = if let Some(timestamp) = identifier.timestamp {
             let rev_reg_id = identifier.rev_reg_id.clone().ok_or_else(|| {

--- a/anoncreds/tests/utils/anoncreds.rs
+++ b/anoncreds/tests/utils/anoncreds.rs
@@ -5,8 +5,8 @@ use anoncreds::data_types::anoncreds::credential::Credential;
 use anoncreds::data_types::anoncreds::master_secret::MasterSecret;
 use indy_utils::did::DidValue;
 
-pub const ISSUER_DID: &'static str = "NcYxiDXkpYi6ov5FcYDi1e";
-pub const PROVER_DID: &'static str = "VsKV7grR1BUE29mG2Fm2kX";
+pub const ISSUER_DID: &str = "NcYxiDXkpYi6ov5FcYDi1e";
+pub const PROVER_DID: &str = "VsKV7grR1BUE29mG2Fm2kX";
 
 pub struct StoredCredDef {
     pub public: CredentialDefinition,


### PR DESCRIPTION
Dependent upon #23, #27, #30, #31

- Remove enum wrapper around the cred def
- Remove V1 suffix after the cred def
- Removes now useless get_attribute function in the FFI layer

I will leave the revocation stuff for now. @whalelephant Feel free to pick this up (removing the V1 suffix after the structures.)

Work funded by the Government of Ontario.