### PR TITLE
add comment about openssl dependency

### DIFF
--- a/anoncreds/Cargo.toml
+++ b/anoncreds/Cargo.toml
@@ -35,6 +35,9 @@ tempfile = "3.1.0"
 thiserror = "1.0"
 ursa = { version = "=0.3.6", default-features = false, features = ["cl_native", "serde"] }
 zeroize = { version = "1.3", optional = true, features = ["zeroize_derive"] }
+# We add the openssl dependency here because ursa does not expose a vendored openssl feature
+# Since we use "cl_native" as a feature, which uses openssl, we can add a vendored build with 
+# the new exposed "vendored" feature
 openssl = { version = "0.10", optional = true }
 
 [dependencies.indy-utils]


### PR DESCRIPTION
@andrewwhitehead I am not sure why it was a dependency, but if we have to keep it for some reason we can of course keep it in.

Signed-off-by: blu3beri <berend@animo.id>