### PR TITLE
Revocation List Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 target
 Cargo.lock
 .DS_Store
+.tmp

--- a/anoncreds/Cargo.toml
+++ b/anoncreds/Cargo.toml
@@ -29,11 +29,12 @@ once_cell = "1.9"
 rand = "0.8.5"
 regex = "1.2.1"
 serde = { version = "1.0", features = ["derive"] }
+bitvec = { version = "1.0.1", features = ["serde"] }
 serde_json = { version = "1.0", features = ["raw_value"]}
 sha2 = "0.10"
 tempfile = "3.1.0"
 thiserror = "1.0"
-ursa = { version = "=0.3.6", default-features = false, features = ["cl_native", "serde"] }
+ursa = { path = "../../../ursa/libursa", default-features = false, features = ["cl_native", "serde"] }
 zeroize = { version = "1.3", optional = true, features = ["zeroize_derive"] }
 # We add the openssl dependency here because ursa does not expose a vendored openssl feature
 # Since we use "cl_native" as a feature, which uses openssl, we can add a vendored build with 

--- a/anoncreds/Cargo.toml
+++ b/anoncreds/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = { version = "1.0", features = ["raw_value"]}
 sha2 = "0.10"
 tempfile = "3.1.0"
 thiserror = "1.0"
-ursa = { path = "../../../ursa/libursa", default-features = false, features = ["cl_native", "serde"] }
+ursa = { version = "=0.3.6", default-features = false, features = ["cl_native", "serde"] }
 zeroize = { version = "1.3", optional = true, features = ["zeroize_derive"] }
 # We add the openssl dependency here because ursa does not expose a vendored openssl feature
 # Since we use "cl_native" as a feature, which uses openssl, we can add a vendored build with 

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -6,7 +6,6 @@ use serde::{
 use std::collections::HashSet;
 
 use crate::{data_types::Validatable, error, impl_anoncreds_object_identifier};
-use ursa::cl::Accumulator;
 
 impl_anoncreds_object_identifier!(RevocationRegistryId);
 
@@ -54,19 +53,20 @@ pub struct RevocationRegistryDeltaV1 {
     pub value: ursa::cl::RevocationRegistryDelta,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RevocationList {
     rev_reg_id: RevocationRegistryId,
     #[serde(with = "serde_revocation_list")]
     revocation_list: bitvec::vec::BitVec,
-    current_accum: Accumulator,
+    #[serde(flatten)]
+    registry: ursa::cl::RevocationRegistry,
     timestamp: u64,
 }
 
 impl From<&RevocationList> for ursa::cl::RevocationRegistry {
     fn from(rev_reg_list: &RevocationList) -> ursa::cl::RevocationRegistry {
-        ursa::cl::RevocationRegistry::from(rev_reg_list.current_accum)
+        rev_reg_list.registry.clone()
     }
 }
 
@@ -86,13 +86,13 @@ impl RevocationList {
     pub fn new(
         rev_reg_id: &str,
         revocation_list: bitvec::vec::BitVec,
-        current_reg: ursa::cl::RevocationRegistry,
+        registry: ursa::cl::RevocationRegistry,
         timestamp: u64,
     ) -> Result<Self, error::Error> {
-        Ok(Self {
+        Ok(RevocationList {
             rev_reg_id: RevocationRegistryId::new(rev_reg_id)?,
             revocation_list,
-            current_accum: current_reg.into(),
+            registry,
             timestamp,
         })
     }
@@ -155,26 +155,27 @@ mod tests {
     use super::*;
     use bitvec::prelude::*;
 
-    const REVOCATION_LIST: &str = "{\"revRegId\":\"reg\",\"revocationList\":[1,1,1,1],\"currentAccum\":\"1 1379509F4D411630D308A5ABB4F422FCE6737B330B1C5FD286AA5C26F2061E60 1 235535CC45D4816C7686C5A402A230B35A62DDE82B4A652E384FD31912C4E4BB 1 0C94B61595FCAEFC892BB98A27D524C97ED0B7ED1CC49AD6F178A59D4199C9A4 1 172482285606DEE8500FC8A13E6A35EC071F8B84F0EB4CD3DD091C0B4CD30E5E 2 095E45DDF417D05FB10933FFC63D474548B7FFFF7888802F07FFFFFF7D07A8A8 1 0000000000000000000000000000000000000000000000000000000000000000\",\"timestamp\":1234}";
+    const REVOCATION_LIST: &str = r#"
+        {
+            "revRegId": "reg",
+            "revocationList": [1, 1, 1, 1],
+            "accum":  "1 1379509F4D411630D308A5ABB4F422FCE6737B330B1C5FD286AA5C26F2061E60 1 235535CC45D4816C7686C5A402A230B35A62DDE82B4A652E384FD31912C4E4BB 1 0C94B61595FCAEFC892BB98A27D524C97ED0B7ED1CC49AD6F178A59D4199C9A4 1 172482285606DEE8500FC8A13E6A35EC071F8B84F0EB4CD3DD091C0B4CD30E5E 2 095E45DDF417D05FB10933FFC63D474548B7FFFF7888802F07FFFFFF7D07A8A8 1 0000000000000000000000000000000000000000000000000000000000000000",
+			 "timestamp": 1234
+        }"#;
 
     #[test]
     fn json_rev_list_can_be_deserialized() {
         let des = serde_json::from_str::<RevocationList>(REVOCATION_LIST).unwrap();
         let expected_state = bitvec![1;4];
-        println!("des state {:?}", des.state());
-        println!("exp state {:?}", expected_state);
         assert_eq!(des.state(), &expected_state);
     }
 
     #[test]
     fn test_revocation_list_roundtrip_serde() {
-        let state = bitvec![1;4];
-        let accum = Accumulator::new().expect("Should be able to create Accumulator");
-        let list = RevocationList::new("MOCK:uri: reg", state, accum.into(), 1234u64).unwrap();
-        let ser = serde_json::to_string(&list).unwrap();
+        let des_from_json = serde_json::from_str::<RevocationList>(REVOCATION_LIST).unwrap();
+        let ser = serde_json::to_string(&des_from_json).unwrap();
         let des = serde_json::from_str::<RevocationList>(&ser).unwrap();
         let ser2 = serde_json::to_string(&des).unwrap();
-        let list_des = serde_json::from_str::<RevocationList>(&ser2).unwrap();
-        assert_eq!(list, list_des)
+        assert_eq!(ser, ser2)
     }
 }

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -55,7 +55,7 @@ pub struct RevocationRegistryDeltaV1 {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RevocationList {
+pub struct RevocationStatusList {
     rev_reg_id: RevocationRegistryId,
     #[serde(with = "serde_revocation_list")]
     revocation_list: bitvec::vec::BitVec,
@@ -64,13 +64,13 @@ pub struct RevocationList {
     timestamp: u64,
 }
 
-impl From<&RevocationList> for ursa::cl::RevocationRegistry {
-    fn from(rev_reg_list: &RevocationList) -> ursa::cl::RevocationRegistry {
+impl From<&RevocationStatusList> for ursa::cl::RevocationRegistry {
+    fn from(rev_reg_list: &RevocationStatusList) -> ursa::cl::RevocationRegistry {
         rev_reg_list.registry.clone()
     }
 }
 
-impl RevocationList {
+impl RevocationStatusList {
     pub(crate) fn timestamp(&self) -> u64 {
         self.timestamp
     }
@@ -89,7 +89,7 @@ impl RevocationList {
         registry: ursa::cl::RevocationRegistry,
         timestamp: u64,
     ) -> Result<Self, error::Error> {
-        Ok(RevocationList {
+        Ok(RevocationStatusList {
             rev_reg_id: RevocationRegistryId::new(rev_reg_id)?,
             revocation_list,
             registry,
@@ -165,16 +165,16 @@ mod tests {
 
     #[test]
     fn json_rev_list_can_be_deserialized() {
-        let des = serde_json::from_str::<RevocationList>(REVOCATION_LIST).unwrap();
+        let des = serde_json::from_str::<RevocationStatusList>(REVOCATION_LIST).unwrap();
         let expected_state = bitvec![1;4];
         assert_eq!(des.state(), &expected_state);
     }
 
     #[test]
     fn test_revocation_list_roundtrip_serde() {
-        let des_from_json = serde_json::from_str::<RevocationList>(REVOCATION_LIST).unwrap();
+        let des_from_json = serde_json::from_str::<RevocationStatusList>(REVOCATION_LIST).unwrap();
         let ser = serde_json::to_string(&des_from_json).unwrap();
-        let des = serde_json::from_str::<RevocationList>(&ser).unwrap();
+        let des = serde_json::from_str::<RevocationStatusList>(&ser).unwrap();
         let ser2 = serde_json::to_string(&des).unwrap();
         assert_eq!(ser, ser2)
     }

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -106,10 +106,7 @@ pub mod serde_revocation_list {
     {
         let mut seq = s.serialize_seq(Some(state.len()))?;
         for element in state {
-            let e = match *element.as_ref() {
-                true => 1,
-                false => 0,
-            };
+            let e = *element as i32;
             seq.serialize_element(&e)?;
         }
         seq.end()
@@ -125,7 +122,10 @@ pub mod serde_revocation_list {
             type Value = bitvec::vec::BitVec;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                formatter.write_str("a seq containing revoation state, i.e. [1, 0, 1]")
+                write!(
+                    formatter,
+                    "a seq containing revoation state, i.e. [1, 0, 1]"
+                )
             }
 
             fn visit_seq<S>(self, mut v: S) -> Result<Self::Value, S::Error>

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -106,9 +106,9 @@ pub mod serde_revocation_list {
     {
         let mut seq = s.serialize_seq(Some(state.len()))?;
         for element in state {
-            let e = match element.as_ref() {
-                &true => 1,
-                &false => 0,
+            let e = match *element.as_ref() {
+                true => 1,
+                false => 0,
             };
             seq.serialize_element(&e)?;
         }

--- a/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
@@ -34,6 +34,17 @@ impl FromStr for IssuanceType {
     }
 }
 
+impl From<IssuanceType> for usize {
+    fn from(value: IssuanceType) -> usize {
+        match value {
+            // Credentials are by default revoked
+            IssuanceType::ISSUANCE_ON_DEMAND => 1,
+            // Credentials are by default not revoked
+            IssuanceType::ISSUANCE_BY_DEFAULT => 0,
+        }
+    }
+}
+
 impl IssuanceType {
     pub fn to_bool(&self) -> bool {
         *self == IssuanceType::ISSUANCE_BY_DEFAULT

--- a/anoncreds/src/ffi/credential.rs
+++ b/anoncreds/src/ffi/credential.rs
@@ -77,7 +77,7 @@ pub extern "C" fn anoncreds_create_credential(
         }
         let rev_reg_id = rev_reg_id
             .as_opt_str()
-            .map(|i| RevocationRegistryId::new(i))
+            .map(RevocationRegistryId::new)
             .transpose()?;
         let enc_values = attr_enc_values.as_slice();
         let mut cred_values = MakeCredentialValues::default();

--- a/anoncreds/src/ffi/revocation.rs
+++ b/anoncreds/src/ffi/revocation.rs
@@ -16,8 +16,9 @@ use crate::services::{
     prover::create_or_update_revocation_state,
     tails::{TailsFileReader, TailsFileWriter},
     types::{
-        CredentialRevocationState, IssuanceType, RegistryType, RevocationList, RevocationRegistry,
+        CredentialRevocationState, IssuanceType, RegistryType, RevocationRegistry,
         RevocationRegistryDefinition, RevocationRegistryDefinitionPrivate, RevocationRegistryDelta,
+        RevocationStatusList,
     },
 };
 
@@ -239,8 +240,8 @@ impl_anoncreds_object_from_json!(
     anoncreds_revocation_registry_delta_from_json
 );
 
-impl_anoncreds_object!(RevocationList, "RevocationList");
-impl_anoncreds_object_from_json!(RevocationList, anoncreds_revocation_list_from_json);
+impl_anoncreds_object!(RevocationStatusList, "RevocationStatusList");
+impl_anoncreds_object_from_json!(RevocationStatusList, anoncreds_revocation_list_from_json);
 
 #[no_mangle]
 pub extern "C" fn anoncreds_create_or_update_revocation_state(

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -299,15 +299,8 @@ pub fn create_or_update_revocation_state(
         } else {
             let list_size = usize::try_from(revoc_reg_def.value.max_cred_num)
                 .map_err(|e| Error::from_msg(crate::ErrorKind::InvalidState, e.to_string()))?;
-            let list = match revoc_reg_def.value.issuance_type {
-                // All cred are revoked by default
-                IssuanceType::ISSUANCE_ON_DEMAND => {
-                    bitvec![1; list_size]
-                }
-                IssuanceType::ISSUANCE_BY_DEFAULT => {
-                    bitvec![0; list_size]
-                }
-            };
+            let bit: usize = revoc_reg_def.value.issuance_type.into();
+            let list = bitvec![bit; list_size];
             _create_index_deltas(
                 rev_reg_list.state_owned().bitxor(list),
                 rev_reg_list.state(),

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -14,7 +14,7 @@ use crate::data_types::anoncreds::{
         AttributeValue, Identifier, RequestedProof, RevealedAttributeGroupInfo,
         RevealedAttributeInfo, SubProofReferent,
     },
-    rev_reg::RevocationList,
+    rev_reg::RevocationStatusList,
     schema::{Schema, SchemaId},
 };
 use crate::error::{Error, Result};
@@ -254,10 +254,10 @@ pub fn create_presentation(
 pub fn create_or_update_revocation_state(
     tails_reader: TailsReader,
     revoc_reg_def: &RevocationRegistryDefinition,
-    rev_reg_list: &RevocationList,
+    rev_reg_list: &RevocationStatusList,
     rev_reg_idx: u32,
     rev_state: Option<&CredentialRevocationState>, // for witness update
-    old_rev_reg_list: Option<&RevocationList>,     // for witness update
+    old_rev_reg_list: Option<&RevocationStatusList>, // for witness update
 ) -> Result<CredentialRevocationState> {
     trace!(
         "create_or_update_revocation_state >>> , tails_reader: {:?}, revoc_reg_def: {:?}, \

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -339,7 +339,7 @@ fn _create_index_deltas(
     revoked: &mut HashSet<u32>,
 ) {
     for i in delta.iter_ones() {
-        if list[i] == true {
+        if list[i] {
             // true means cred has been revoked
             revoked.insert(i as u32);
         } else {

--- a/anoncreds/src/services/types.rs
+++ b/anoncreds/src/services/types.rs
@@ -9,7 +9,7 @@ pub use crate::data_types::anoncreds::{
     master_secret::MasterSecret,
     pres_request::PresentationRequest,
     presentation::Presentation,
-    rev_reg::{RevocationRegistry, RevocationRegistryDelta},
+    rev_reg::{RevocationList, RevocationRegistry, RevocationRegistryDelta},
     rev_reg_def::{
         IssuanceType, RegistryType, RevocationRegistryDefinition,
         RevocationRegistryDefinitionPrivate,
@@ -200,9 +200,9 @@ pub(crate) struct ProvingCredentialKey {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CredentialRevocationState {
-    pub(crate) witness: Witness,
-    pub(crate) rev_reg: CryptoRevocationRegistry,
-    pub(crate) timestamp: u64,
+    pub witness: Witness,
+    pub rev_reg: CryptoRevocationRegistry,
+    pub timestamp: u64,
 }
 
 impl Validatable for CredentialRevocationState {

--- a/anoncreds/src/services/types.rs
+++ b/anoncreds/src/services/types.rs
@@ -9,7 +9,7 @@ pub use crate::data_types::anoncreds::{
     master_secret::MasterSecret,
     pres_request::PresentationRequest,
     presentation::Presentation,
-    rev_reg::{RevocationList, RevocationRegistry, RevocationRegistryDelta},
+    rev_reg::{RevocationRegistry, RevocationRegistryDelta, RevocationStatusList},
     rev_reg_def::{
         IssuanceType, RegistryType, RevocationRegistryDefinition,
         RevocationRegistryDefinitionPrivate,

--- a/anoncreds/src/services/verifier.rs
+++ b/anoncreds/src/services/verifier.rs
@@ -71,6 +71,8 @@ pub fn verify_presentation(
         &received_self_attested_attrs,
     )?;
 
+    // makes sure the for revocable request or attribute,
+    // there is a timestamp in the `Identifier`
     compare_timestamps_from_proof_and_request(
         pres_req,
         &received_revealed_attrs,
@@ -112,6 +114,7 @@ pub fn verify_presentation(
                 ));
             }
 
+            // Revocation registry definition id is the same as the rev reg id
             let rev_reg_def_id = RevocationRegistryDefinitionId::new(rev_reg_id.clone())?;
             let rev_reg_def = Some(
                 rev_reg_defs
@@ -303,6 +306,8 @@ fn compare_attr_from_proof_and_request(
     Ok(())
 }
 
+// This does not actually compare the non_revoke interval
+// see `validate_timestamp` function comments
 fn compare_timestamps_from_proof_and_request(
     pres_req: &PresentationRequestPayload,
     received_revealed_attrs: &HashMap<String, Identifier>,
@@ -353,6 +358,19 @@ fn compare_timestamps_from_proof_and_request(
     Ok(())
 }
 
+// This validates that a timestamp is given if either:
+// - the `global_interval` rev requirement
+// - the `local_interval` rev requirement
+// from the PresentationRequest are satisfied.
+//
+// If either the attribute nor the request has a revocation internal
+// i.e. they are non-revocable, then `OK` is returned directly.
+//
+// Otherwise the Identifier for the referent (attribute) has to have a timestamp,
+// which was added by the prover when creating `PresentCredentials`,
+// an arg for `create_presentation`. 
+// 
+// TODO: this timestamp should be compared with the provided interval
 fn validate_timestamp(
     received_: &HashMap<String, Identifier>,
     referent: &str,

--- a/anoncreds/src/services/verifier.rs
+++ b/anoncreds/src/services/verifier.rs
@@ -368,8 +368,8 @@ fn compare_timestamps_from_proof_and_request(
 //
 // Otherwise the Identifier for the referent (attribute) has to have a timestamp,
 // which was added by the prover when creating `PresentCredentials`,
-// an arg for `create_presentation`. 
-// 
+// an arg for `create_presentation`.
+//
 // TODO: this timestamp should be compared with the provided interval
 fn validate_timestamp(
     received_: &HashMap<String, Identifier>,

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -5,17 +5,18 @@ use std::{
 
 use anoncreds::{
     data_types::anoncreds::{
-        cred_def::CredentialDefinitionId, presentation::Presentation,
-        rev_reg::RevocationRegistryId, rev_reg_def::RevocationRegistryDefinitionId,
-        schema::SchemaId,
+        cred_def::{CredentialDefinition, CredentialDefinitionId},
+        presentation::Presentation,
+        rev_reg::RevocationRegistryId,
+        rev_reg_def::RevocationRegistryDefinitionId,
+        schema::{Schema, SchemaId},
     },
     issuer, prover,
     tails::{TailsFileReader, TailsFileWriter},
     types::{
-        CredentialDefinition, CredentialDefinitionConfig, CredentialRevocationConfig,
-        CredentialRevocationState, IssuanceType, MakeCredentialValues, PresentCredentials,
-        PresentationRequest, RegistryType, RevocationList, RevocationRegistry,
-        RevocationRegistryDefinition, Schema, SignatureType,
+        CredentialDefinitionConfig, CredentialRevocationConfig, CredentialRevocationState,
+        IssuanceType, MakeCredentialValues, PresentCredentials, PresentationRequest, RegistryType,
+        RevocationList, RevocationRegistry, RevocationRegistryDefinition, SignatureType,
     },
     verifier,
 };

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -16,7 +16,7 @@ use anoncreds::{
     types::{
         CredentialDefinitionConfig, CredentialRevocationConfig, CredentialRevocationState,
         IssuanceType, MakeCredentialValues, PresentCredentials, PresentationRequest, RegistryType,
-        RevocationList, RevocationRegistry, RevocationRegistryDefinition, SignatureType,
+        RevocationRegistry, RevocationRegistryDefinition, RevocationStatusList, SignatureType,
     },
     verifier,
 };
@@ -469,7 +469,7 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
     };
 
     let revocation_list =
-        RevocationList::new(REV_REG_ID, list, ursa_rev_reg, prover_timestamp).unwrap();
+        RevocationStatusList::new(REV_REG_ID, list, ursa_rev_reg, prover_timestamp).unwrap();
     let new_rev_state = prover::create_or_update_revocation_state(
         tr,
         &rev_reg_def_pub,


### PR DESCRIPTION
This is the first PR introducing RevocationList model outlined in https://github.com/hyperledger/anoncreds-spec/issues/108 and #24.

- introduce `RevocationList` struct with serde to match outlined json, with tests
- update `create_or_update_revocation_state` function for prover and FFI. This now takes in either 1 `RevocationList` to create or optionally an old one, does a comparison and update the revocation state.
- initial end to end test in `anoncreds_demo`

Additional documentation is added to highlight the unchecked interval, which I am looking into for #36 and #41
