### PR TITLE
update revocation registry definition

### DIFF
--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -10,48 +10,28 @@ use crate::{data_types::Validatable, error, impl_anoncreds_object_identifier};
 impl_anoncreds_object_identifier!(RevocationRegistryId);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "ver")]
-pub enum RevocationRegistry {
-    #[serde(rename = "1.0")]
-    RevocationRegistryV1(RevocationRegistryV1),
+pub struct RevocationRegistry {
+    pub value: ursa::cl::RevocationRegistry,
 }
 
 impl RevocationRegistry {
     pub fn initial_delta(&self) -> RevocationRegistryDelta {
-        match self {
-            Self::RevocationRegistryV1(v1) => {
-                RevocationRegistryDelta::RevocationRegistryDeltaV1(RevocationRegistryDeltaV1 {
-                    value: {
-                        let empty = HashSet::new();
-                        ursa::cl::RevocationRegistryDelta::from_parts(
-                            None, &v1.value, &empty, &empty,
-                        )
-                    },
-                })
-            }
+        RevocationRegistryDelta {
+            value: {
+                let empty = HashSet::new();
+                ursa::cl::RevocationRegistryDelta::from_parts(None, &self.value, &empty, &empty)
+            },
         }
     }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct RevocationRegistryV1 {
-    pub value: ursa::cl::RevocationRegistry,
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "ver")]
-pub enum RevocationRegistryDelta {
-    #[serde(rename = "1.0")]
-    RevocationRegistryDeltaV1(RevocationRegistryDeltaV1),
+#[serde(rename_all = "camelCase")]
+pub struct RevocationRegistryDelta {
+    pub value: ursa::cl::RevocationRegistryDelta,
 }
 
 impl Validatable for RevocationRegistryDelta {}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RevocationRegistryDeltaV1 {
-    pub value: ursa::cl::RevocationRegistryDelta,
-}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -63,6 +63,10 @@ impl RevocationStatusList {
         self.revocation_list.clone()
     }
 
+    pub(crate) fn get(&self, idx: usize) -> Option<bool> {
+        self.revocation_list.get(idx).as_deref().copied()
+    }
+
     pub fn new(
         rev_reg_id: &str,
         revocation_list: bitvec::vec::BitVec,

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -36,7 +36,7 @@ impl Validatable for RevocationRegistryDelta {}
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RevocationStatusList {
-    rev_reg_id: RevocationRegistryId,
+    rev_reg_def_id: RevocationRegistryId,
     #[serde(with = "serde_revocation_list")]
     revocation_list: bitvec::vec::BitVec,
     #[serde(flatten)]
@@ -45,8 +45,8 @@ pub struct RevocationStatusList {
 }
 
 impl From<&RevocationStatusList> for ursa::cl::RevocationRegistry {
-    fn from(rev_reg_list: &RevocationStatusList) -> ursa::cl::RevocationRegistry {
-        rev_reg_list.registry.clone()
+    fn from(rev_status_list: &RevocationStatusList) -> ursa::cl::RevocationRegistry {
+        rev_status_list.registry.clone()
     }
 }
 
@@ -68,13 +68,13 @@ impl RevocationStatusList {
     }
 
     pub fn new(
-        rev_reg_id: &str,
+        rev_reg_def_id: &str,
         revocation_list: bitvec::vec::BitVec,
         registry: ursa::cl::RevocationRegistry,
         timestamp: u64,
     ) -> Result<Self, error::Error> {
         Ok(RevocationStatusList {
-            rev_reg_id: RevocationRegistryId::new(rev_reg_id)?,
+            rev_reg_def_id: RevocationRegistryId::new(rev_reg_def_id)?,
             revocation_list,
             registry,
             timestamp,
@@ -141,7 +141,7 @@ mod tests {
 
     const REVOCATION_LIST: &str = r#"
         {
-            "revRegId": "reg",
+            "revRegDefId": "reg",
             "revocationList": [1, 1, 1, 1],
             "accum":  "1 1379509F4D411630D308A5ABB4F422FCE6737B330B1C5FD286AA5C26F2061E60 1 235535CC45D4816C7686C5A402A230B35A62DDE82B4A652E384FD31912C4E4BB 1 0C94B61595FCAEFC892BB98A27D524C97ED0B7ED1CC49AD6F178A59D4199C9A4 1 172482285606DEE8500FC8A13E6A35EC071F8B84F0EB4CD3DD091C0B4CD30E5E 2 095E45DDF417D05FB10933FFC63D474548B7FFFF7888802F07FFFFFF7D07A8A8 1 0000000000000000000000000000000000000000000000000000000000000000",
 			 "timestamp": 1234

--- a/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
@@ -9,47 +9,8 @@ use super::cred_def::CredentialDefinitionId;
 
 pub const CL_ACCUM: &str = "CL_ACCUM";
 
-pub const ISSUANCE_BY_DEFAULT: &str = "ISSUANCE_BY_DEFAULT";
-pub const ISSUANCE_ON_DEMAND: &str = "ISSUANCE_ON_DEMAND";
-
 impl_anoncreds_object_identifier!(RevocationRegistryDefinitionId);
 
-#[allow(non_camel_case_types)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Default)]
-pub enum IssuanceType {
-    #[default]
-    ISSUANCE_BY_DEFAULT,
-    ISSUANCE_ON_DEMAND,
-}
-
-impl FromStr for IssuanceType {
-    type Err = ConversionError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            ISSUANCE_BY_DEFAULT => Ok(Self::ISSUANCE_BY_DEFAULT),
-            ISSUANCE_ON_DEMAND => Ok(Self::ISSUANCE_ON_DEMAND),
-            _ => Err(ConversionError::from_msg("Invalid issuance type")),
-        }
-    }
-}
-
-impl From<IssuanceType> for usize {
-    fn from(value: IssuanceType) -> usize {
-        match value {
-            // Credentials are by default revoked
-            IssuanceType::ISSUANCE_ON_DEMAND => 1,
-            // Credentials are by default not revoked
-            IssuanceType::ISSUANCE_BY_DEFAULT => 0,
-        }
-    }
-}
-
-impl IssuanceType {
-    pub fn to_bool(&self) -> bool {
-        *self == IssuanceType::ISSUANCE_BY_DEFAULT
-    }
-}
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub enum RegistryType {
@@ -70,7 +31,6 @@ impl FromStr for RegistryType {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RevocationRegistryDefinitionValue {
-    pub issuance_type: IssuanceType,
     pub max_cred_num: u32,
     pub public_keys: RevocationRegistryDefinitionValuePublicKeys,
     pub tails_hash: String,

--- a/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
@@ -5,7 +5,7 @@ use crate::{
     impl_anoncreds_object_identifier,
 };
 
-use super::cred_def::CredentialDefinitionId;
+use super::{cred_def::CredentialDefinitionId, issuer_id::IssuerId};
 
 pub const CL_ACCUM: &str = "CL_ACCUM";
 
@@ -46,6 +46,7 @@ pub struct RevocationRegistryDefinitionValuePublicKeys {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RevocationRegistryDefinition {
+    pub issuer_id: IssuerId,
     pub revoc_def_type: RegistryType,
     pub tag: String,
     pub cred_def_id: CredentialDefinitionId,

--- a/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
@@ -84,22 +84,15 @@ pub struct RevocationRegistryDefinitionValuePublicKeys {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(tag = "ver")]
-pub enum RevocationRegistryDefinition {
-    #[serde(rename = "1.0")]
-    RevocationRegistryDefinitionV1(RevocationRegistryDefinitionV1),
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RevocationRegistryDefinitionV1 {
+pub struct RevocationRegistryDefinition {
     pub revoc_def_type: RegistryType,
     pub tag: String,
     pub cred_def_id: CredentialDefinitionId,
     pub value: RevocationRegistryDefinitionValue,
 }
 
-impl Validatable for RevocationRegistryDefinitionV1 {
+impl Validatable for RevocationRegistryDefinition {
     fn validate(&self) -> Result<(), ValidationError> {
         self.cred_def_id.validate()
     }

--- a/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg_def.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use crate::{
-    data_types::{invalid, ConversionError, Validatable, ValidationError},
+    data_types::{ConversionError, Validatable, ValidationError},
     impl_anoncreds_object_identifier,
 };
 
@@ -108,21 +108,4 @@ impl Validatable for RevocationRegistryDefinitionV1 {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct RevocationRegistryDefinitionPrivate {
     pub value: ursa::cl::RevocationKeyPrivate,
-}
-
-#[derive(Deserialize, Debug, Serialize)]
-pub struct RevocationRegistryConfig {
-    pub issuance_type: Option<IssuanceType>,
-    pub max_cred_num: Option<u32>,
-}
-
-impl Validatable for RevocationRegistryConfig {
-    fn validate(&self) -> Result<(), ValidationError> {
-        if let Some(num_) = self.max_cred_num {
-            if num_ == 0 {
-                return Err(invalid!("RevocationRegistryConfig validation failed: `max_cred_num` must be greater than 0"));
-            }
-        }
-        Ok(())
-    }
 }

--- a/anoncreds/src/ffi/credential.rs
+++ b/anoncreds/src/ffi/credential.rs
@@ -60,6 +60,7 @@ pub extern "C" fn anoncreds_create_credential(
     attr_raw_values: FfiStrList,
     attr_enc_values: FfiStrList,
     rev_reg_id: FfiStr,
+    rev_reg_list: ObjectHandle,
     revocation: *const FfiCredRevInfo,
     cred_p: *mut ObjectHandle,
     rev_reg_p: *mut ObjectHandle,
@@ -135,6 +136,7 @@ pub extern "C" fn anoncreds_create_credential(
         } else {
             None
         };
+
         let (cred, rev_reg, rev_delta) = create_credential(
             cred_def.load()?.cast_ref()?,
             cred_def_private.load()?.cast_ref()?,
@@ -142,6 +144,7 @@ pub extern "C" fn anoncreds_create_credential(
             cred_request.load()?.cast_ref()?,
             cred_values.into(),
             rev_reg_id,
+            rev_reg_list.load()?.cast_ref().ok(),
             revocation_config
                 .as_ref()
                 .map(RevocationConfig::as_ref_config)

--- a/anoncreds/src/ffi/credential.rs
+++ b/anoncreds/src/ffi/credential.rs
@@ -60,7 +60,7 @@ pub extern "C" fn anoncreds_create_credential(
     attr_raw_values: FfiStrList,
     attr_enc_values: FfiStrList,
     rev_reg_id: FfiStr,
-    rev_reg_list: ObjectHandle,
+    rev_status_list: ObjectHandle,
     revocation: *const FfiCredRevInfo,
     cred_p: *mut ObjectHandle,
     rev_reg_p: *mut ObjectHandle,
@@ -144,7 +144,7 @@ pub extern "C" fn anoncreds_create_credential(
             cred_request.load()?.cast_ref()?,
             cred_values.into(),
             rev_reg_id,
-            rev_reg_list.load()?.cast_ref().ok(),
+            rev_status_list.load()?.cast_ref().ok(),
             revocation_config
                 .as_ref()
                 .map(RevocationConfig::as_ref_config)

--- a/anoncreds/src/ffi/revocation.rs
+++ b/anoncreds/src/ffi/revocation.rs
@@ -180,21 +180,9 @@ pub extern "C" fn anoncreds_revocation_registry_definition_get_attribute(
         let reg_def = handle.load()?;
         let reg_def = reg_def.cast_ref::<RevocationRegistryDefinition>()?;
         let val = match name.as_opt_str().unwrap_or_default() {
-            "max_cred_num" => match reg_def {
-                RevocationRegistryDefinition::RevocationRegistryDefinitionV1(r) => {
-                    r.value.max_cred_num.to_string()
-                }
-            },
-            "tails_hash" => match reg_def {
-                RevocationRegistryDefinition::RevocationRegistryDefinitionV1(r) => {
-                    r.value.tails_hash.to_string()
-                }
-            },
-            "tails_location" => match reg_def {
-                RevocationRegistryDefinition::RevocationRegistryDefinitionV1(r) => {
-                    r.value.tails_location.to_string()
-                }
-            },
+            "max_cred_num" => reg_def.value.max_cred_num.to_string(),
+            "tails_hash" => reg_def.value.tails_hash.to_string(),
+            "tails_location" => reg_def.value.tails_location.to_string(),
             s => return Err(err_msg!("Unsupported attribute: {}", s)),
         };
         unsafe { *result_p = rust_string_to_c(val) };

--- a/anoncreds/src/ffi/revocation.rs
+++ b/anoncreds/src/ffi/revocation.rs
@@ -25,6 +25,7 @@ use crate::services::{
 pub extern "C" fn anoncreds_create_revocation_registry(
     cred_def: ObjectHandle,
     cred_def_id: FfiStr,
+    issuer_id: FfiStr,
     tag: FfiStr,
     rev_reg_type: FfiStr,
     max_cred_num: i64,
@@ -43,6 +44,9 @@ pub extern "C" fn anoncreds_create_revocation_registry(
         let cred_def_id = cred_def_id
             .as_opt_str()
             .ok_or_else(|| err_msg!("Missing cred def id"))?;
+        let issuer_id = issuer_id
+            .as_opt_str()
+            .ok_or_else(|| err_msg!("Missing issuer id"))?;
         let rev_reg_type = {
             let rtype = rev_reg_type
                 .as_opt_str()
@@ -53,6 +57,7 @@ pub extern "C" fn anoncreds_create_revocation_registry(
         let (reg_def, reg_def_private, reg_entry, reg_init_delta) = create_revocation_registry(
             cred_def.load()?.cast_ref()?,
             cred_def_id,
+            issuer_id,
             tag,
             rev_reg_type,
             max_cred_num

--- a/anoncreds/src/ffi/revocation.rs
+++ b/anoncreds/src/ffi/revocation.rs
@@ -16,9 +16,8 @@ use crate::services::{
     prover::create_or_update_revocation_state,
     tails::{TailsFileReader, TailsFileWriter},
     types::{
-        CredentialRevocationState, IssuanceType, RegistryType, RevocationRegistry,
-        RevocationRegistryDefinition, RevocationRegistryDefinitionPrivate, RevocationRegistryDelta,
-        RevocationStatusList,
+        CredentialRevocationState, RegistryType, RevocationRegistry, RevocationRegistryDefinition,
+        RevocationRegistryDefinitionPrivate, RevocationRegistryDelta, RevocationStatusList,
     },
 };
 
@@ -28,7 +27,6 @@ pub extern "C" fn anoncreds_create_revocation_registry(
     cred_def_id: FfiStr,
     tag: FfiStr,
     rev_reg_type: FfiStr,
-    issuance_type: FfiStr,
     max_cred_num: i64,
     tails_dir_path: FfiStr,
     reg_def_p: *mut ObjectHandle,
@@ -51,17 +49,12 @@ pub extern "C" fn anoncreds_create_revocation_registry(
                 .ok_or_else(|| err_msg!("Missing registry type"))?;
             RegistryType::from_str(rtype).map_err(err_map!(Input))?
         };
-        let issuance_type = match issuance_type.as_opt_str() {
-            Some(s) => IssuanceType::from_str(s).map_err(err_map!(Input))?,
-            None => IssuanceType::default(),
-        };
         let mut tails_writer = TailsFileWriter::new(tails_dir_path.into_opt_string());
         let (reg_def, reg_def_private, reg_entry, reg_init_delta) = create_revocation_registry(
             cred_def.load()?.cast_ref()?,
             cred_def_id,
             tag,
             rev_reg_type,
-            issuance_type,
             max_cred_num
                 .try_into()
                 .map_err(|_| err_msg!("Invalid maximum credential count"))?,

--- a/anoncreds/src/ffi/revocation.rs
+++ b/anoncreds/src/ffi/revocation.rs
@@ -232,17 +232,17 @@ impl_anoncreds_object_from_json!(RevocationStatusList, anoncreds_revocation_list
 #[no_mangle]
 pub extern "C" fn anoncreds_create_or_update_revocation_state(
     rev_reg_def: ObjectHandle,
-    rev_reg_list: ObjectHandle,
+    rev_status_list: ObjectHandle,
     rev_reg_index: i64,
     tails_path: FfiStr,
     rev_state: ObjectHandle,
-    old_rev_reg_list: ObjectHandle,
+    old_rev_status_list: ObjectHandle,
     rev_state_p: *mut ObjectHandle,
 ) -> ErrorCode {
     catch_error(|| {
         check_useful_c_ptr!(rev_state_p);
         let prev_rev_state = rev_state.opt_load()?;
-        let prev_rev_reg_list = old_rev_reg_list.opt_load()?;
+        let prev_rev_status_list = old_rev_status_list.opt_load()?;
         let tails_reader = TailsFileReader::new_tails_reader(
             tails_path
                 .as_opt_str()
@@ -251,7 +251,7 @@ pub extern "C" fn anoncreds_create_or_update_revocation_state(
         let rev_state = create_or_update_revocation_state(
             tails_reader,
             rev_reg_def.load()?.cast_ref()?,
-            rev_reg_list.load()?.cast_ref()?,
+            rev_status_list.load()?.cast_ref()?,
             rev_reg_index
                 .try_into()
                 .map_err(|_| err_msg!("Invalid credential revocation index"))?,
@@ -259,7 +259,7 @@ pub extern "C" fn anoncreds_create_or_update_revocation_state(
                 .as_ref()
                 .map(AnonCredsObject::cast_ref)
                 .transpose()?,
-            prev_rev_reg_list
+            prev_rev_status_list
                 .as_ref()
                 .map(AnonCredsObject::cast_ref)
                 .transpose()?,

--- a/anoncreds/src/services/issuer.rs
+++ b/anoncreds/src/services/issuer.rs
@@ -119,6 +119,7 @@ where
 pub fn create_revocation_registry<TW>(
     cred_def: &CredentialDefinition,
     cred_def_id: impl TryInto<CredentialDefinitionId, Error = ValidationError>,
+    issuer_id: impl TryInto<IssuerId, Error = ValidationError>,
     tag: &str,
     rev_reg_type: RegistryType,
     max_cred_num: u32,
@@ -135,6 +136,7 @@ where
     trace!("create_revocation_registry >>> cred_def: {:?}, tag: {:?}, max_cred_num: {:?}, rev_reg_type: {:?}",
              cred_def, tag, max_cred_num, rev_reg_type);
     let cred_def_id = cred_def_id.try_into()?;
+    let issuer_id = issuer_id.try_into()?;
 
     let credential_pub_key = cred_def.get_public_key().map_err(err_map!(
         Unexpected,
@@ -161,6 +163,7 @@ where
 
     let revoc_reg_def = RevocationRegistryDefinition {
         revoc_def_type: rev_reg_type,
+        issuer_id,
         tag: tag.to_string(),
         cred_def_id,
         value: revoc_reg_def_value,

--- a/anoncreds/src/services/issuer.rs
+++ b/anoncreds/src/services/issuer.rs
@@ -278,14 +278,19 @@ pub fn create_credential(
     let prover_did = cred_request.prover_did.as_ref().unwrap_or(&rand_str);
 
     let (credential_signature, signature_correctness_proof, rev_reg, rev_reg_delta, witness) =
-        match (revocation_config, rev_status_list ) {
+        match (revocation_config, rev_status_list) {
             (Some(revocation_config), Some(rev_status_list)) => {
                 let rev_reg_def = &revocation_config.reg_def.value;
                 let mut rev_reg = revocation_config.registry.value.clone();
 
-                let status = rev_status_list.get(revocation_config.registry_idx as usize).ok_or_else(||
-                    err_msg!("Revocation status list does not have the index {}", revocation_config.registry_idx)
-                )?;
+                let status = rev_status_list
+                    .get(revocation_config.registry_idx as usize)
+                    .ok_or_else(|| {
+                        err_msg!(
+                            "Revocation status list does not have the index {}",
+                            revocation_config.registry_idx
+                        )
+                    })?;
 
                 // This will be a temporary solution for the `issuance_on_demand` vs
                 // `issuance_by_default` state. Right now, we pass in the revcation status list and
@@ -295,7 +300,7 @@ pub fn create_credential(
                 //
                 // If the index is inside the revocation status list we check whether it is set to
                 // `true` or `false` within the bitvec.
-                // When it is set to `true`, or 1, we invert the value. This means that we use 
+                // When it is set to `true`, or 1, we invert the value. This means that we use
                 // `issuance_on_demand`.
                 // When it is set to `false`, or 0, we invert the value. This means that we use
                 // `issuance_by_default`.
@@ -321,7 +326,8 @@ pub fn create_credential(
 
                 let witness = {
                     let empty = HashSet::new();
-                    let (by_default, issued, revoked) = (true, &empty, revocation_config.registry_used);
+                    let (by_default, issued, revoked) =
+                        (true, &empty, revocation_config.registry_used);
 
                     let rev_reg_delta =
                         CryptoRevocationRegistryDelta::from_parts(None, &rev_reg, issued, revoked);

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -104,12 +104,7 @@ pub fn process_credential(
     )?;
     let credential_values =
         build_credential_values(&credential.values.0, Some(&master_secret.value))?;
-    let rev_pub_key = match rev_reg_def {
-        Some(RevocationRegistryDefinition::RevocationRegistryDefinitionV1(def)) => {
-            Some(&def.value.public_keys.accum_key)
-        }
-        _ => None,
-    };
+    let rev_pub_key = rev_reg_def.map(|d| &d.value.public_keys.accum_key);
 
     CryptoProver::process_credential_signature(
         &mut credential.signature,
@@ -270,7 +265,6 @@ pub fn create_or_update_revocation_state(
         old_rev_reg_list,
     );
 
-    let RevocationRegistryDefinition::RevocationRegistryDefinitionV1(revoc_reg_def) = revoc_reg_def;
     let mut issued = HashSet::<u32>::new();
     let mut revoked = HashSet::<u32>::new();
     let witness =

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -293,7 +293,8 @@ pub fn create_or_update_revocation_state(
         } else {
             let list_size = usize::try_from(revoc_reg_def.value.max_cred_num)
                 .map_err(|e| Error::from_msg(crate::ErrorKind::InvalidState, e.to_string()))?;
-            let bit: usize = revoc_reg_def.value.issuance_type.into();
+            // Issuance by default
+            let bit: usize = 0;
             let list = bitvec![bit; list_size];
             _create_index_deltas(
                 rev_reg_list.state_owned().bitxor(list),
@@ -306,7 +307,8 @@ pub fn create_or_update_revocation_state(
             Witness::new(
                 rev_reg_idx,
                 revoc_reg_def.value.max_cred_num,
-                revoc_reg_def.value.issuance_type.to_bool(),
+                // issuance by default
+                true,
                 &rev_reg_delta,
                 &tails_reader,
             )?

--- a/anoncreds/src/services/prover.rs
+++ b/anoncreds/src/services/prover.rs
@@ -249,75 +249,78 @@ pub fn create_presentation(
 pub fn create_or_update_revocation_state(
     tails_reader: TailsReader,
     revoc_reg_def: &RevocationRegistryDefinition,
-    rev_reg_list: &RevocationStatusList,
+    rev_status_list: &RevocationStatusList,
     rev_reg_idx: u32,
     rev_state: Option<&CredentialRevocationState>, // for witness update
-    old_rev_reg_list: Option<&RevocationStatusList>, // for witness update
+    old_rev_status_list: Option<&RevocationStatusList>, // for witness update
 ) -> Result<CredentialRevocationState> {
     trace!(
         "create_or_update_revocation_state >>> , tails_reader: {:?}, revoc_reg_def: {:?}, \
-    rev_reg_list: {:?}, rev_reg_idx: {},  rev_state: {:?}, old_rev_reg_list {:?}",
+    rev_status_list: {:?}, rev_reg_idx: {},  rev_state: {:?}, old_rev_status_list {:?}",
         tails_reader,
         revoc_reg_def,
-        rev_reg_list,
+        rev_status_list,
         rev_reg_idx,
         rev_state,
-        old_rev_reg_list,
+        old_rev_status_list,
     );
 
     let mut issued = HashSet::<u32>::new();
     let mut revoked = HashSet::<u32>::new();
-    let witness =
-        if let (Some(source_rev_state), Some(source_rev_list)) = (rev_state, old_rev_reg_list) {
-            _create_index_deltas(
-                rev_reg_list.state_owned().bitxor(source_rev_list.state()),
-                rev_reg_list.state(),
-                &mut issued,
-                &mut revoked,
-            );
+    let witness = if let (Some(source_rev_state), Some(source_rev_list)) =
+        (rev_state, old_rev_status_list)
+    {
+        _create_index_deltas(
+            rev_status_list
+                .state_owned()
+                .bitxor(source_rev_list.state()),
+            rev_status_list.state(),
+            &mut issued,
+            &mut revoked,
+        );
 
-            let rev_reg_delta = RevocationRegistryDelta::from_parts(
-                Some(&source_rev_list.into()),
-                &rev_reg_list.into(),
-                &issued,
-                &revoked,
-            );
-            let mut witness = source_rev_state.witness.clone();
-            witness.update(
-                rev_reg_idx,
-                revoc_reg_def.value.max_cred_num,
-                &rev_reg_delta,
-                &tails_reader,
-            )?;
-            witness
-        } else {
-            let list_size = usize::try_from(revoc_reg_def.value.max_cred_num)
-                .map_err(|e| Error::from_msg(crate::ErrorKind::InvalidState, e.to_string()))?;
-            // Issuance by default
-            let bit: usize = 0;
-            let list = bitvec![bit; list_size];
-            _create_index_deltas(
-                rev_reg_list.state_owned().bitxor(list),
-                rev_reg_list.state(),
-                &mut issued,
-                &mut revoked,
-            );
-            let rev_reg_delta =
-                RevocationRegistryDelta::from_parts(None, &rev_reg_list.into(), &issued, &revoked);
-            Witness::new(
-                rev_reg_idx,
-                revoc_reg_def.value.max_cred_num,
-                // issuance by default
-                true,
-                &rev_reg_delta,
-                &tails_reader,
-            )?
-        };
+        let rev_reg_delta = RevocationRegistryDelta::from_parts(
+            Some(&source_rev_list.into()),
+            &rev_status_list.into(),
+            &issued,
+            &revoked,
+        );
+        let mut witness = source_rev_state.witness.clone();
+        witness.update(
+            rev_reg_idx,
+            revoc_reg_def.value.max_cred_num,
+            &rev_reg_delta,
+            &tails_reader,
+        )?;
+        witness
+    } else {
+        let list_size = usize::try_from(revoc_reg_def.value.max_cred_num)
+            .map_err(|e| Error::from_msg(crate::ErrorKind::InvalidState, e.to_string()))?;
+        // Issuance by default
+        let bit: usize = 0;
+        let list = bitvec![bit; list_size];
+        _create_index_deltas(
+            rev_status_list.state_owned().bitxor(list),
+            rev_status_list.state(),
+            &mut issued,
+            &mut revoked,
+        );
+        let rev_reg_delta =
+            RevocationRegistryDelta::from_parts(None, &rev_status_list.into(), &issued, &revoked);
+        Witness::new(
+            rev_reg_idx,
+            revoc_reg_def.value.max_cred_num,
+            // issuance by default
+            true,
+            &rev_reg_delta,
+            &tails_reader,
+        )?
+    };
 
     Ok(CredentialRevocationState {
         witness,
-        rev_reg: rev_reg_list.into(),
-        timestamp: rev_reg_list.timestamp(),
+        rev_reg: rev_status_list.into(),
+        timestamp: rev_status_list.timestamp(),
     })
 }
 

--- a/anoncreds/src/services/types.rs
+++ b/anoncreds/src/services/types.rs
@@ -11,8 +11,7 @@ pub use crate::data_types::anoncreds::{
     presentation::Presentation,
     rev_reg::{RevocationRegistry, RevocationRegistryDelta, RevocationStatusList},
     rev_reg_def::{
-        IssuanceType, RegistryType, RevocationRegistryDefinition,
-        RevocationRegistryDefinitionPrivate,
+        RegistryType, RevocationRegistryDefinition, RevocationRegistryDefinitionPrivate,
     },
     schema::AttributeNames,
 };

--- a/anoncreds/src/services/verifier.rs
+++ b/anoncreds/src/services/verifier.rs
@@ -173,14 +173,8 @@ pub fn verify_presentation(
             cred_def.value.revocation.as_ref(),
         )?;
 
-        let rev_key_pub = rev_reg_def.as_ref().map(|r_reg_def| match r_reg_def {
-            RevocationRegistryDefinition::RevocationRegistryDefinitionV1(reg_def) => {
-                &reg_def.value.public_keys.accum_key
-            }
-        });
-        let rev_reg = rev_reg.as_ref().map(|r_reg| match r_reg {
-            RevocationRegistry::RevocationRegistryV1(reg_def) => &reg_def.value,
-        });
+        let rev_key_pub = rev_reg_def.map(|d| &d.value.public_keys.accum_key);
+        let rev_reg = rev_reg.map(|r| &r.value);
 
         proof_verifier.add_sub_proof_request(
             &sub_pres_request,

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -15,7 +15,7 @@ use anoncreds::{
     tails::{TailsFileReader, TailsFileWriter},
     types::{
         CredentialDefinitionConfig, CredentialRevocationConfig, CredentialRevocationState,
-        IssuanceType, MakeCredentialValues, PresentCredentials, PresentationRequest, RegistryType,
+        MakeCredentialValues, PresentCredentials, PresentationRequest, RegistryType,
         RevocationStatusList, SignatureType,
     },
     verifier,
@@ -286,7 +286,6 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
         CRED_DEF_ID,
         "some_tag",
         RegistryType::CL_ACCUM,
-        IssuanceType::ISSUANCE_BY_DEFAULT,
         MAX_CRED_NUM,
         &mut tf,
     )

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -111,6 +111,7 @@ fn anoncreds_works_for_single_issuer_single_prover() {
         cred_values.into(),
         None,
         None,
+        None,
     )
     .expect("Error creating credential");
 

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -16,7 +16,7 @@ use anoncreds::{
     types::{
         CredentialDefinitionConfig, CredentialRevocationConfig, CredentialRevocationState,
         IssuanceType, MakeCredentialValues, PresentCredentials, PresentationRequest, RegistryType,
-        RevocationRegistry, RevocationRegistryDefinition, RevocationStatusList, SignatureType,
+        RevocationStatusList, SignatureType,
     },
     verifier,
 };
@@ -339,11 +339,8 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
     let rev_reg_id = RevocationRegistryId::new_unchecked(REV_REG_ID);
 
     // Get the location of the tails_file so it can be read
-    let location = match rev_reg_def_pub.clone() {
-        RevocationRegistryDefinition::RevocationRegistryDefinitionV1(value) => {
-            value.value.tails_location
-        }
-    };
+    let location = rev_reg_def_pub.clone().value.tails_location;
+
     let tr = TailsFileReader::new_tails_reader(location.as_str());
 
     // The Prover's index in the revocation list is REV_IDX
@@ -414,9 +411,8 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
     // Prover: here we deliberately do not put in the same timestamp as the global non_revoked time interval,
     // this shows that it is not used
     let prover_timestamp = 1234u64;
-    let rev_reg = match cred_rev_reg.clone() {
-        RevocationRegistry::RevocationRegistryV1(r) => r.value,
-    };
+    let rev_reg = cred_rev_reg.value.clone();
+
     let rev_state = CredentialRevocationState {
         timestamp: prover_timestamp,
         rev_reg: rev_reg.clone(),
@@ -477,9 +473,7 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
     // revoked_bit is not a reference so can drop
     drop(revoked_bit);
 
-    let ursa_rev_reg = match revoked_rev_reg.clone() {
-        RevocationRegistry::RevocationRegistryV1(v) => v.value,
-    };
+    let ursa_rev_reg = revoked_rev_reg.value.clone();
 
     let revocation_list =
         RevocationStatusList::new(REV_REG_ID, list, ursa_rev_reg, prover_timestamp).unwrap();

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -284,6 +284,7 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
     let (rev_reg_def_pub, rev_reg_def_priv, rev_reg, _) = issuer::create_revocation_registry(
         &cred_def_pub,
         CRED_DEF_ID,
+        ISSUER_ID,
         "some_tag",
         RegistryType::CL_ACCUM,
         MAX_CRED_NUM,

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -337,7 +337,7 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
         .add_raw("age", "28")
         .expect("Error encoding attribute");
 
-    let rev_reg_def_id = RevocationRegistryId::new_unchecked(REV_REG_ID);
+    let rev_reg_id = RevocationRegistryId::new_unchecked(REV_REG_ID);
 
     // Get the location of the tails_file so it can be read
     let location = rev_reg_def_pub.clone().value.tails_location;
@@ -358,7 +358,7 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
         &cred_offer,
         &cred_request,
         cred_values.into(),
-        Some(rev_reg_def_id.clone()),
+        Some(rev_reg_id.clone()),
         Some(&revocation_status_list),
         Some(CredentialRevocationConfig {
             reg_def: &rev_reg_def_pub,

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anoncreds::{
-   data_types::anoncreds::{
+    data_types::anoncreds::{
         cred_def::{CredentialDefinition, CredentialDefinitionId},
         presentation::Presentation,
         rev_reg::RevocationRegistryId,
@@ -483,8 +483,13 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
 
     let ursa_rev_reg = revoked_rev_reg.clone().value;
 
-    let revocation_list =
-        RevocationStatusList::new(Some(REV_REG_ID), list, Some(ursa_rev_reg), Some(prover_timestamp)).unwrap();
+    let revocation_list = RevocationStatusList::new(
+        Some(REV_REG_ID),
+        list,
+        Some(ursa_rev_reg),
+        Some(prover_timestamp),
+    )
+    .unwrap();
     let new_rev_state = prover::create_or_update_revocation_state(
         tr,
         &rev_reg_def_pub,


### PR DESCRIPTION
closes #22 

Where it was required, e.g. we pass it to Ursa, I used `ISSUANCE_BY_DEFAULT` which is a 0 or true.

@whalelephant could you also give this a review with regards to any revocation changes, I am not too familiar with the exact internals so just to be safe.

- removed the revocation registry config type
- removed V1 wrapper around revocation objects
- removed issuance by default reference
