### PR TITLE
Tests: multiple credentials

### DIFF
--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -87,8 +87,8 @@ impl RevocationStatusList {
     pub(crate) fn update(
         &mut self,
         registry: Option<ursa::cl::RevocationRegistry>,
-        issued: Option<&BTreeSet<u32>>,
-        revoked: Option<&BTreeSet<u32>>,
+        issued: Option<BTreeSet<u32>>,
+        revoked: Option<BTreeSet<u32>>,
         timestamp: Option<u64>,
     ) -> Result<(), error::Error> {
         if let Some(reg) = registry {
@@ -98,7 +98,7 @@ impl RevocationStatusList {
             // issued credentials are assigned `false`
             // i.e. NOT revoked
             for i in issued {
-                let mut bit = self.revocation_list.get_mut(*i as usize).ok_or_else(|| {
+                let mut bit = self.revocation_list.get_mut(i as usize).ok_or_else(|| {
                     error::Error::from_msg(
                         crate::ErrorKind::Unexpected,
                         "Update Revocation List Index Out of Range",
@@ -111,7 +111,7 @@ impl RevocationStatusList {
             // revoked credentials are assigned `true`
             // i.e. IS revoked
             for i in revoked {
-                let mut bit = self.revocation_list.get_mut(*i as usize).ok_or_else(|| {
+                let mut bit = self.revocation_list.get_mut(i as usize).ok_or_else(|| {
                     error::Error::from_msg(
                         crate::ErrorKind::Unexpected,
                         "Update Revocation List Index Out of Range",
@@ -231,7 +231,7 @@ mod tests {
         assert_eq!(list.timestamp().unwrap(), 1234);
         assert_eq!(list_status.get(0usize).unwrap(), true);
 
-        list.update(None, Some(&BTreeSet::from([0u32])), None, Some(1245))
+        list.update(None, Some(BTreeSet::from([0u32])), None, Some(1245))
             .unwrap();
         assert_eq!(list.get(0usize).unwrap(), false);
         assert_eq!(list.timestamp().unwrap(), 1245);

--- a/anoncreds/src/data_types/anoncreds/rev_reg.rs
+++ b/anoncreds/src/data_types/anoncreds/rev_reg.rs
@@ -3,9 +3,11 @@ use serde::{
     de::{Deserializer, Error as DeError, SeqAccess, Visitor},
     ser::{SerializeSeq, Serializer},
 };
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 
 use crate::{data_types::Validatable, error, impl_anoncreds_object_identifier};
+
+use super::rev_reg_def::RevocationRegistryDefinitionId;
 
 impl_anoncreds_object_identifier!(RevocationRegistryId);
 
@@ -37,7 +39,7 @@ impl Validatable for RevocationRegistryDelta {}
 #[serde(rename_all = "camelCase")]
 pub struct RevocationStatusList {
     #[serde(skip_serializing_if = "Option::is_none")]
-    rev_reg_def_id: Option<RevocationRegistryId>,
+    rev_reg_def_id: Option<RevocationRegistryDefinitionId>,
     #[serde(with = "serde_revocation_list")]
     revocation_list: bitvec::vec::BitVec,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -49,6 +51,15 @@ pub struct RevocationStatusList {
 impl From<&RevocationStatusList> for Option<ursa::cl::RevocationRegistry> {
     fn from(rev_status_list: &RevocationStatusList) -> Option<ursa::cl::RevocationRegistry> {
         rev_status_list.registry.clone()
+    }
+}
+
+impl From<&RevocationStatusList> for Option<RevocationRegistry> {
+    fn from(rev_status_list: &RevocationStatusList) -> Option<RevocationRegistry> {
+        rev_status_list
+            .registry
+            .clone()
+            .map(|v| RevocationRegistry { value: v })
     }
 }
 
@@ -73,6 +84,48 @@ impl RevocationStatusList {
         self.revocation_list.get(idx).as_deref().copied()
     }
 
+    pub(crate) fn update(
+        &mut self,
+        registry: Option<ursa::cl::RevocationRegistry>,
+        issued: Option<&BTreeSet<u32>>,
+        revoked: Option<&BTreeSet<u32>>,
+        timestamp: Option<u64>,
+    ) -> Result<(), error::Error> {
+        if let Some(reg) = registry {
+            self.registry = Some(reg)
+        };
+        if let Some(issued) = issued {
+            // issued credentials are assigned `false`
+            // i.e. NOT revoked
+            for i in issued {
+                let mut bit = self.revocation_list.get_mut(*i as usize).ok_or_else(|| {
+                    error::Error::from_msg(
+                        crate::ErrorKind::Unexpected,
+                        "Update Revocation List Index Out of Range",
+                    )
+                })?;
+                *bit = false;
+            }
+        }
+        if let Some(revoked) = revoked {
+            // revoked credentials are assigned `true`
+            // i.e. IS revoked
+            for i in revoked {
+                let mut bit = self.revocation_list.get_mut(*i as usize).ok_or_else(|| {
+                    error::Error::from_msg(
+                        crate::ErrorKind::Unexpected,
+                        "Update Revocation List Index Out of Range",
+                    )
+                })?;
+                *bit = true;
+            }
+        }
+        if let Some(t) = timestamp {
+            self.timestamp = Some(t);
+        }
+        Ok(())
+    }
+
     pub fn new(
         rev_reg_def_id: Option<&str>,
         revocation_list: bitvec::vec::BitVec,
@@ -80,7 +133,9 @@ impl RevocationStatusList {
         timestamp: Option<u64>,
     ) -> Result<Self, error::Error> {
         Ok(RevocationStatusList {
-            rev_reg_def_id: rev_reg_def_id.map(RevocationRegistryId::new).transpose()?,
+            rev_reg_def_id: rev_reg_def_id
+                .map(RevocationRegistryDefinitionId::new)
+                .transpose()?,
             revocation_list,
             registry,
             timestamp,
@@ -167,5 +222,18 @@ mod tests {
         let des = serde_json::from_str::<RevocationStatusList>(&ser).unwrap();
         let ser2 = serde_json::to_string(&des).unwrap();
         assert_eq!(ser, ser2)
+    }
+
+    #[test]
+    fn update_rev_status_list_works() {
+        let mut list = serde_json::from_str::<RevocationStatusList>(REVOCATION_LIST).unwrap();
+        let list_status = list.state_owned();
+        assert_eq!(list.timestamp().unwrap(), 1234);
+        assert_eq!(list_status.get(0usize).unwrap(), true);
+
+        list.update(None, Some(&BTreeSet::from([0u32])), None, Some(1245))
+            .unwrap();
+        assert_eq!(list.get(0usize).unwrap(), false);
+        assert_eq!(list.timestamp().unwrap(), 1245);
     }
 }

--- a/anoncreds/src/ffi/credential.rs
+++ b/anoncreds/src/ffi/credential.rs
@@ -30,7 +30,6 @@ pub struct FfiCredRevInfo<'a> {
 struct RevocationConfig {
     reg_def: AnonCredsObject,
     reg_def_private: AnonCredsObject,
-    registry: AnonCredsObject,
     reg_idx: u32,
     tails_path: String,
 }
@@ -40,7 +39,6 @@ impl RevocationConfig {
         Ok(CredentialRevocationConfig {
             reg_def: self.reg_def.cast_ref()?,
             reg_def_private: self.reg_def_private.cast_ref()?,
-            registry: self.registry.cast_ref()?,
             registry_idx: self.reg_idx,
             tails_reader: TailsFileReader::new_tails_reader(self.tails_path.as_str()),
         })
@@ -112,7 +110,6 @@ pub extern "C" fn anoncreds_create_credential(
             Some(RevocationConfig {
                 reg_def: revocation.reg_def.load()?,
                 reg_def_private: revocation.reg_def_private.load()?,
-                registry: revocation.registry.load()?,
                 reg_idx: revocation
                     .reg_idx
                     .try_into()

--- a/anoncreds/src/ffi/revocation.rs
+++ b/anoncreds/src/ffi/revocation.rs
@@ -14,6 +14,7 @@ use crate::services::{
         RevocationRegistryDefinitionPrivate, RevocationRegistryDelta, RevocationStatusList,
     },
 };
+// TODO: interfaces to create
 //use crate::services::issuer::{create_revocation_status_list, update_revocation_status_list}
 
 #[no_mangle]

--- a/anoncreds/src/services/issuer.rs
+++ b/anoncreds/src/services/issuer.rs
@@ -332,7 +332,10 @@ pub fn create_credential(
         match (revocation_config, rev_status_list) {
             (Some(revocation_config), Some(rev_status_list)) => {
                 let rev_reg_def = &revocation_config.reg_def.value;
-                let mut rev_reg = revocation_config.registry.value.clone();
+                let mut rev_reg = <&RevocationStatusList as Into<
+                    Option<ursa::cl::RevocationRegistry>,
+                >>::into(rev_status_list)
+                .unwrap();
 
                 let status = rev_status_list
                     .get(revocation_config.registry_idx as usize)
@@ -423,7 +426,7 @@ pub fn create_credential(
         values: cred_values,
         signature: credential_signature,
         signature_correctness_proof,
-        rev_reg: rev_reg.clone(),
+        rev_reg,
         witness,
     };
 

--- a/anoncreds/src/services/types.rs
+++ b/anoncreds/src/services/types.rs
@@ -217,9 +217,9 @@ impl Validatable for CredentialRevocationState {
 pub struct CredentialRevocationConfig<'a> {
     pub reg_def: &'a RevocationRegistryDefinition,
     pub reg_def_private: &'a RevocationRegistryDefinitionPrivate,
+    // TODO remove this!
     pub registry: &'a RevocationRegistry,
     pub registry_idx: u32,
-    pub registry_used: &'a HashSet<u32>,
     pub tails_reader: TailsReader,
 }
 

--- a/anoncreds/src/services/types.rs
+++ b/anoncreds/src/services/types.rs
@@ -217,8 +217,6 @@ impl Validatable for CredentialRevocationState {
 pub struct CredentialRevocationConfig<'a> {
     pub reg_def: &'a RevocationRegistryDefinition,
     pub reg_def_private: &'a RevocationRegistryDefinitionPrivate,
-    // TODO remove this!
-    pub registry: &'a RevocationRegistry,
     pub registry_idx: u32,
     pub tails_reader: TailsReader,
 }
@@ -227,10 +225,9 @@ impl<'a> std::fmt::Debug for CredentialRevocationConfig<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "CredentialRevocationConfig {{ reg_def: {:?}, private: {:?}, registry: {:?}, idx: {}, reader: {:?} }}",
+            "CredentialRevocationConfig {{ reg_def: {:?}, private: {:?}, idx: {}, reader: {:?} }}",
             self.reg_def,
             secret!(self.reg_def_private),
-            self.registry,
             secret!(self.registry_idx),
             self.tails_reader,
         )

--- a/anoncreds/src/services/verifier.rs
+++ b/anoncreds/src/services/verifier.rs
@@ -335,7 +335,7 @@ fn compare_timestamps_from_proof_and_request(
                 received_self_attested_attrs
                     .get(referent)
                     .map(|_| ())
-                    .ok_or_else(|| err_msg!("Missing referent"))
+                    .ok_or_else(|| err_msg!("Missing referent: {}", referent))
             })
         })
         .collect::<Result<Vec<()>>>()?;

--- a/anoncreds/tests/anoncreds_demos.rs
+++ b/anoncreds/tests/anoncreds_demos.rs
@@ -377,10 +377,10 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
 
     let time_after_creating_cred = time_create_rev_status_list + 1;
     let issued_rev_status_list = issuer::update_revocation_status_list(
-        time_after_creating_cred,
-        BTreeSet::from([REV_IDX]),
-        BTreeSet::new(),
-        &rev_reg_def_pub,
+        Some(time_after_creating_cred),
+        Some(BTreeSet::from([REV_IDX])),
+        None,
+        Some(&rev_reg_def_pub),
         &revocation_status_list,
     )
     .unwrap();
@@ -477,10 +477,10 @@ fn anoncreds_with_revocation_works_for_single_issuer_single_prover() {
     //  ===================== Issuer revokes credential ================
     let time_revoke_cred = time_after_creating_cred + 1;
     let revoked_status_list = issuer::update_revocation_status_list(
-        time_revoke_cred,
-        BTreeSet::new(),
-        BTreeSet::from([REV_IDX]),
-        &rev_reg_def_pub,
+        Some(time_revoke_cred),
+        None,
+        Some(BTreeSet::from([REV_IDX])),
+        Some(&rev_reg_def_pub),
         &issued_rev_status_list,
     )
     .unwrap();

--- a/anoncreds/tests/multiple-credentials.rs
+++ b/anoncreds/tests/multiple-credentials.rs
@@ -1,0 +1,202 @@
+use std::collections::HashMap;
+
+use anoncreds::{
+    data_types::anoncreds::{
+        pres_request::{NonRevocedInterval, PresentationRequestPayload},
+        schema::SchemaId,
+    },
+    types::PresentationRequest,
+    verifier,
+};
+
+use serde_json::json;
+
+mod utils;
+
+pub static ISSUER_ID: &str = "mock:issuer_id/path&q=bar";
+pub static PROVER_ID: &str = "mock:prover_id/path&q=bar";
+pub static REV_IDX_1: u32 = 9;
+pub static REV_IDX_2: u32 = 9;
+pub static MAX_CRED_NUM: u32 = 10;
+pub static TF_PATH: &str = "../.tmp";
+const SCHEMA_ID_1: &str = "mock:uri:schema1";
+const SCHEMA_ID_2: &str = "mock:uri:schema2";
+const SCHEMA_1: &str = r#"{"name":"gvt","version":"1.0","attrNames":["name","sex","age","height"],"issuerId":"mock:issuer_id/path&q=bar"}"#;
+const SCHEMA_2: &str = r#"{"name":"hogwarts","version":"1.0","attrNames":["wand","house","year"],"issuerId":"mock:issuer_id/path&q=hogwarts"}"#;
+static CRED_DEF_ID_1: &'static str = "mock:uri:1";
+static CRED_DEF_ID_2: &'static str = "mock:uri:2";
+static REV_REG_ID_1: &'static str = "mock:uri:revregid1";
+static REV_REG_ID_2: &'static str = "mock:uri:revregid2";
+
+// Credential 1 is revocable
+// Credential 2 is non-revocable
+// There are 2 definitions, issued by 2 issuers
+fn test_2_different_revoke_reqs() -> Vec<PresentationRequest> {
+    let nonce_1 = verifier::generate_nonce().expect("Error generating presentation request nonce");
+    let nonce_2 = verifier::generate_nonce().expect("Error generating presentation request nonce");
+
+    let json = json!({
+        "nonce": nonce_1,
+        "name":"pres_req_1",
+        "version":"0.1",
+        "requested_attributes":{
+            "attr1_referent":{
+                "name":"name",
+                "issuer_id": ISSUER_ID
+            },
+            "attr2_referent":{
+                "name":"sex"
+            },
+            "attr3_referent":{"name":"phone"},
+            "attr4_referent":{
+                "names": ["height"],
+            },
+            "attr5_referent": {"names": ["wand", "house", "year"]},
+
+        },
+        "requested_predicates":{
+            "predicate1_referent":{"name":"age","p_type":">=","p_value":18}
+        },
+    });
+
+    let mut p1: PresentationRequestPayload = serde_json::from_value(json.clone()).unwrap();
+    let mut p2: PresentationRequestPayload = serde_json::from_value(json).unwrap();
+
+    // Global non_revoked
+    p1.non_revoked = Some(NonRevocedInterval {
+        from: Some(10),
+        to: Some(20),
+    });
+    p1.nonce = nonce_1;
+    p2.nonce = nonce_2;
+
+    // Local non_revoked
+    if let Some(at) = p2.requested_attributes.get_mut("attr4_referent") {
+        at.non_revoked = Some(NonRevocedInterval {
+            from: Some(10),
+            to: Some(20),
+        })
+    } else {
+        panic!("Cannot add non_revoke to attri");
+    }
+
+    vec![
+        PresentationRequest::PresentationRequestV1(p1),
+        PresentationRequest::PresentationRequestV1(p2),
+    ]
+}
+
+#[test]
+fn anoncreds_with_multiple_credentials_per_request() {
+    let mut mock = utils::Mock::new(&[ISSUER_ID], &[PROVER_ID], TF_PATH, MAX_CRED_NUM);
+
+    // These are what the issuer knows
+    let issuer1_creds: utils::IsserValues = HashMap::from([
+        (
+            CRED_DEF_ID_1,
+            (
+                SCHEMA_ID_1,
+                HashMap::from([
+                    ("sex", "male"),
+                    ("name", "Alex"),
+                    ("height", "175"),
+                    ("age", "28"),
+                ]),
+                true,
+                REV_REG_ID_1,
+                REV_IDX_1,
+            ),
+        ),
+        (
+            CRED_DEF_ID_2,
+            (
+                SCHEMA_ID_2,
+                HashMap::from([
+                    ("wand", "dragon-heart-string"),
+                    ("house", "Hufflepuff"),
+                    ("year", "1990"),
+                ]),
+                // Issue 42 addresses if it is not revocable,
+                // revocation should still pass
+                true,
+                REV_REG_ID_2,
+                REV_IDX_2,
+            ),
+        ),
+    ]);
+
+    let schemas = HashMap::from([
+        (
+            SchemaId::new_unchecked(SCHEMA_ID_1),
+            serde_json::from_str(SCHEMA_1).unwrap(),
+        ),
+        (
+            SchemaId::new_unchecked(SCHEMA_ID_2),
+            serde_json::from_str(SCHEMA_2).unwrap(),
+        ),
+    ]);
+
+    mock.ledger.schemas = schemas;
+
+    // This is out of range of revoke interval, should get warning
+    let time_initial_rev_reg = 123u64;
+    let time_after_credential = 124u64;
+    let issuance_by_default = true;
+
+    // To test:
+    // pres_request_1: global interval; Tests verification for revocable credentials only
+    // pres_request_2: local intervals for both credential; Tests verification for revocable credentials only
+    // Verifier creates a presentation request for each
+    let reqs = test_2_different_revoke_reqs();
+
+    // 1: Issuer setup (credate cred defs, rev defs(optional), cred_offers)
+    mock.issuer_setup(
+        ISSUER_ID,
+        PROVER_ID,
+        &issuer1_creds,
+        time_initial_rev_reg,
+        issuance_by_default,
+    );
+
+    // 2: prover requests and gets credential stored in their wallets
+    mock.issuer_create_credential_and_store_in_prover_wallet(
+        ISSUER_ID,
+        PROVER_ID,
+        &issuer1_creds,
+        time_initial_rev_reg,
+        time_after_credential,
+    );
+
+    // 3. Prover creates revocation states for all credentials with ledger values
+    // rev_states are stored in the prover wallet
+    mock.prover_creates_revocation_states(PROVER_ID, time_after_credential);
+
+    // 4. Prover create presentations
+    let prover_values: utils::ProverValues = HashMap::from([
+        (
+            CRED_DEF_ID_1,
+            (
+                vec!["attr1_referent", "attr2_referent", "attr4_referent"],
+                vec!["predicate1_referent"],
+            ),
+        ),
+        (CRED_DEF_ID_2, (vec!["attr5_referent"], vec![])),
+    ]);
+    let self_attested = HashMap::from([("attr3_referent".to_string(), "8-800-300".to_string())]);
+
+    let mut presentations = vec![];
+    for req in &reqs {
+        let p = mock.prover_creates_presentation(
+            PROVER_ID,
+            prover_values.clone(),
+            self_attested.clone(),
+            req,
+        );
+        presentations.push(p)
+    }
+    // 5. Verifier verifies one presentation per request
+    let results = mock.verifer_verifies_presentations_for_requests(presentations, &reqs);
+
+    assert!(results[0]);
+    assert!(results[1]);
+}

--- a/anoncreds/tests/utils/anoncreds.rs
+++ b/anoncreds/tests/utils/anoncreds.rs
@@ -1,61 +1,76 @@
-use anoncreds::types::{CredentialDefinitionPrivate, CredentialKeyCorrectnessProof};
-
-use anoncreds::data_types::anoncreds::cred_def::CredentialDefinition;
+use anoncreds::data_types::anoncreds::cred_def::{CredentialDefinition, CredentialDefinitionId};
 use anoncreds::data_types::anoncreds::credential::Credential;
 use anoncreds::data_types::anoncreds::master_secret::MasterSecret;
+use anoncreds::data_types::anoncreds::rev_reg::RevocationRegistryId;
+use anoncreds::data_types::anoncreds::rev_reg_def::{
+    RevocationRegistryDefinition, RevocationRegistryDefinitionId,
+    RevocationRegistryDefinitionPrivate,
+};
+use anoncreds::data_types::anoncreds::schema::{Schema, SchemaId};
+use anoncreds::types::{
+    CredentialDefinitionPrivate, CredentialKeyCorrectnessProof, CredentialOffer, CredentialRequest,
+    CredentialRequestMetadata, CredentialRevocationState, RevocationStatusList,
+};
+use std::collections::HashMap;
 
+#[derive(Debug)]
 pub struct StoredCredDef {
-    pub public: CredentialDefinition,
     pub private: CredentialDefinitionPrivate,
     pub key_proof: CredentialKeyCorrectnessProof,
 }
 
-impl
-    From<(
-        CredentialDefinition,
-        CredentialDefinitionPrivate,
-        CredentialKeyCorrectnessProof,
-    )> for StoredCredDef
-{
-    fn from(
-        parts: (
-            CredentialDefinition,
-            CredentialDefinitionPrivate,
-            CredentialKeyCorrectnessProof,
-        ),
-    ) -> Self {
-        let (public, private, key_proof) = parts;
+#[derive(Debug)]
+pub struct StoredRevDef {
+    pub public: RevocationRegistryDefinition,
+    pub private: RevocationRegistryDefinitionPrivate,
+}
+
+#[derive(Debug, Default)]
+pub struct Ledger<'a> {
+    // CredentialDefinition does not impl Clone
+    pub cred_defs: HashMap<CredentialDefinitionId, CredentialDefinition>,
+    pub schemas: HashMap<SchemaId, Schema>,
+    pub rev_reg_defs: HashMap<RevocationRegistryDefinitionId, RevocationRegistryDefinition>,
+    pub revcation_list: HashMap<&'a str, HashMap<u64, RevocationStatusList>>,
+}
+
+// A struct for keeping all issuer-related objects together
+#[derive(Debug)]
+pub struct IssuerWallet<'a> {
+    // cred_def_id: StoredRevDef
+    pub cred_defs: HashMap<&'a str, StoredCredDef>,
+    // revocation_reg_id: StoredRevDef
+    pub rev_defs: HashMap<&'a str, StoredRevDef>,
+}
+
+impl<'a> Default for IssuerWallet<'a> {
+    fn default() -> Self {
         Self {
-            public,
-            private,
-            key_proof,
+            cred_defs: HashMap::new(),
+            rev_defs: HashMap::new(),
         }
     }
 }
 
 // A struct for keeping all issuer-related objects together
-pub struct IssuerWallet {
-    pub cred_defs: Vec<StoredCredDef>,
-}
-
-impl Default for IssuerWallet {
-    fn default() -> Self {
-        Self { cred_defs: vec![] }
-    }
-}
-
-// A struct for keeping all issuer-related objects together
-pub struct ProverWallet {
+#[derive(Debug)]
+pub struct ProverWallet<'a> {
     pub credentials: Vec<Credential>,
+    pub rev_states: HashMap<RevocationRegistryId, (Option<CredentialRevocationState>, Option<u64>)>,
     pub master_secret: MasterSecret,
+    pub cred_offers: HashMap<&'a str, CredentialOffer>,
+    pub cred_reqs: Vec<(CredentialRequest, CredentialRequestMetadata)>,
 }
 
-impl Default for ProverWallet {
+impl<'a> Default for ProverWallet<'a> {
     fn default() -> Self {
         let master_secret = MasterSecret::new().expect("Error creating prover master secret");
         Self {
             credentials: vec![],
+            rev_states: HashMap::new(),
             master_secret,
+            cred_offers: HashMap::new(),
+            cred_reqs: vec![],
         }
     }
 }

--- a/anoncreds/tests/utils/mock.rs
+++ b/anoncreds/tests/utils/mock.rs
@@ -1,0 +1,449 @@
+use super::anoncreds::{IssuerWallet, Ledger, ProverWallet, StoredCredDef, StoredRevDef};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fs::create_dir,
+};
+
+use anoncreds::{
+    data_types::anoncreds::{
+        cred_def::{CredentialDefinition, CredentialDefinitionId},
+        cred_offer::CredentialOffer,
+        credential::Credential,
+        presentation::Presentation,
+        rev_reg::{RevocationRegistry, RevocationRegistryId},
+        rev_reg_def::RevocationRegistryDefinitionId,
+        schema::{Schema, SchemaId},
+    },
+    issuer, prover,
+    tails::{TailsFileReader, TailsFileWriter},
+    types::{
+        CredentialDefinitionConfig, CredentialRequest, CredentialRevocationConfig,
+        MakeCredentialValues, PresentCredentials, PresentationRequest, RegistryType, SignatureType,
+    },
+    verifier,
+};
+
+// {cred_def_id: {
+//       schema_id, credential_values, support_revocation, rev_reg_id, rev_idx
+// }}
+pub type IsserValues<'a> =
+    HashMap<&'a str, (&'a str, HashMap<&'a str, &'a str>, bool, &'a str, u32)>;
+
+// {cred_def_id: {
+//       attribute_per_credential, predicate_for_credential }}
+pub type ProverValues<'a> = HashMap<&'a str, (Vec<&'a str>, Vec<&'a str>)>;
+
+#[derive(Debug)]
+pub struct Mock<'a> {
+    pub issuer_wallets: HashMap<&'a str, IssuerWallet<'a>>,
+    pub prover_wallets: HashMap<&'a str, ProverWallet<'a>>,
+    pub ledger: Ledger<'a>,
+    pub tails_path: &'a str,
+    pub max_cred_num: u32,
+}
+
+impl<'a> Mock<'a> {
+    pub fn new(
+        issuer_ids: &[&'a str],
+        prover_ids: &[&'a str],
+        tails_path: &'a str,
+        max_cred_num: u32,
+    ) -> Self {
+        let mut iws = HashMap::new();
+        let mut pws = HashMap::new();
+        for i in issuer_ids {
+            iws.insert(*i, IssuerWallet::default());
+        }
+        for i in prover_ids {
+            pws.insert(*i, ProverWallet::default());
+        }
+
+        Self {
+            issuer_wallets: iws,
+            prover_wallets: pws,
+            ledger: Ledger::default(),
+            tails_path,
+            max_cred_num,
+        }
+    }
+
+    pub fn verifer_verifies_presentations_for_requests(
+        &self,
+        presentations: Vec<Presentation>,
+        reqs: &[PresentationRequest],
+    ) -> Vec<bool> {
+        let mut results = vec![];
+        let schemas: HashMap<&SchemaId, &Schema> = HashMap::from_iter(self.ledger.schemas.iter());
+        let cred_defs: HashMap<&CredentialDefinitionId, &CredentialDefinition> =
+            HashMap::from_iter(self.ledger.cred_defs.iter());
+        let rev_reg_map: HashMap<RevocationRegistryId, HashMap<u64, RevocationRegistry>> =
+            HashMap::from_iter(self.ledger.revcation_list.iter().map(|(&k, v)| {
+                (
+                    RevocationRegistryId::new_unchecked(k),
+                    HashMap::from_iter(v.iter().map(|(&time, v)| {
+                        let rev_reg: Option<RevocationRegistry> = v.into();
+                        (time, rev_reg.unwrap())
+                    })),
+                )
+            }));
+        let rev_reg_def_map = HashMap::from_iter(self.ledger.rev_reg_defs.iter());
+
+        for (i, presentation) in presentations.iter().enumerate() {
+            let valid = verifier::verify_presentation(
+                &presentation,
+                &reqs[i],
+                &schemas,
+                &cred_defs,
+                Some(&rev_reg_def_map),
+                Some(&HashMap::from_iter(rev_reg_map.iter().map(|(k, v)| {
+                    (
+                        k.clone(),
+                        HashMap::from_iter(v.iter().map(|(k, v)| (*k, v))),
+                    )
+                }))),
+            )
+            .expect("Error verifying presentation");
+            results.push(valid);
+        }
+        results
+    }
+
+    // This creates cred defs based on the schemas, assumes 1 schema 1 cred def
+    // issuer wallet holds all data relating to cred def and rev def
+    // prover wallet contains the cred offers from the credentials
+    // ledger holds the rev reg def / rev reg info
+    pub fn issuer_setup(
+        &mut self,
+        issuer_id: &'static str,
+        prover_id: &'static str,
+        values: &'a IsserValues,
+        time_now: u64,
+        issuance_by_default: bool,
+    ) {
+        for (cred_def_id, (schema_id, _, support_revocation, rev_reg_id, _)) in values.iter() {
+            let (cred_def_pub, cred_def_priv, cred_def_correctness) =
+                issuer::create_credential_definition(
+                    schema_id.to_string(),
+                    &self.ledger.schemas[&SchemaId::new_unchecked(*schema_id)],
+                    issuer_id,
+                    "tag",
+                    SignatureType::CL,
+                    CredentialDefinitionConfig {
+                        support_revocation: *support_revocation,
+                    },
+                )
+                .expect("Error creating gvt credential definition");
+
+            if *support_revocation {
+                // This will create a tails file locally in the .tmp dir
+                create_dir(self.tails_path)
+                    .or_else(|e| -> Result<(), std::io::Error> {
+                        println!(
+                            "Tail file path creation error but test can still proceed {}",
+                            e
+                        );
+                        Ok(())
+                    })
+                    .unwrap();
+
+                let mut tf = TailsFileWriter::new(Some(self.tails_path.to_owned()));
+                let (rev_reg_def_pub, rev_reg_def_priv) = issuer::create_revocation_registry_def(
+                    &cred_def_pub,
+                    *cred_def_id,
+                    issuer_id,
+                    "some_tag",
+                    RegistryType::CL_ACCUM,
+                    self.max_cred_num,
+                    &mut tf,
+                )
+                .unwrap();
+
+                let iw_mut = self.issuer_wallets.get_mut(issuer_id).unwrap();
+                iw_mut.rev_defs.insert(
+                    &rev_reg_id,
+                    StoredRevDef {
+                        public: rev_reg_def_pub.clone(),
+                        private: rev_reg_def_priv,
+                    },
+                );
+
+                let revocation_status_list = issuer::create_revocation_status_list(
+                    *rev_reg_id,
+                    &rev_reg_def_pub,
+                    Some(time_now),
+                    issuance_by_default,
+                )
+                .unwrap();
+
+                self.ledger.revcation_list.insert(
+                    rev_reg_id,
+                    HashMap::from([(time_now, revocation_status_list)]),
+                );
+
+                self.ledger.rev_reg_defs.insert(
+                    RevocationRegistryDefinitionId::new_unchecked(*rev_reg_id),
+                    rev_reg_def_pub,
+                );
+            }
+
+            // Issuer creates a Credential Offer
+            let cred_offer = issuer::create_credential_offer(
+                schema_id.to_string(),
+                *cred_def_id,
+                &cred_def_correctness,
+            )
+            .expect("Error creating credential offer");
+
+            // Update wallets and ledger
+            self.prover_wallets
+                .get_mut(prover_id)
+                .unwrap()
+                .cred_offers
+                .insert(*cred_def_id, cred_offer);
+
+            self.issuer_wallets
+                .get_mut(issuer_id)
+                .unwrap()
+                .cred_defs
+                .insert(
+                    *cred_def_id,
+                    StoredCredDef {
+                        private: cred_def_priv,
+                        key_proof: cred_def_correctness,
+                    },
+                );
+            self.ledger.cred_defs.insert(
+                CredentialDefinitionId::new_unchecked(*cred_def_id),
+                cred_def_pub,
+            );
+        }
+    }
+
+    fn issuer_create_credential(
+        &self,
+        issuer_wallet: &IssuerWallet,
+        ledger: &Ledger,
+        cred_request: &CredentialRequest,
+        offer: &CredentialOffer,
+        rev_reg_id: &str,
+        cred_def_id: &str,
+        values: &HashMap<&str, &str>,
+        prev_rev_reg_time: u64,
+        rev_idx: u32,
+    ) -> Credential {
+        let schema = self.ledger.schemas.get(&offer.schema_id).unwrap();
+        let revocation_list = self
+            .ledger
+            .revcation_list
+            .get(rev_reg_id)
+            .map(|h| h.get(&prev_rev_reg_time))
+            .flatten();
+        let mut cred_values = MakeCredentialValues::default();
+        let names: Vec<String> = schema.attr_names.clone().0.into_iter().collect();
+        for (i, v) in names.iter().enumerate() {
+            if let Some(value) = values.get(&v.as_str()) {
+                cred_values
+                    .add_raw(names[i].clone(), value.to_string())
+                    .expect("Error encoding attribute");
+            } else {
+                panic!(
+                    "No credential value given for attribute name: {} in {:?}",
+                    v, values
+                );
+            }
+        }
+
+        let (rev_config, rev_id) = match issuer_wallet.rev_defs.get(rev_reg_id) {
+            Some(stored_rev_def) => {
+                let tr = TailsFileReader::new_tails_reader(
+                    stored_rev_def.public.value.tails_location.as_str(),
+                );
+                (
+                    Some(CredentialRevocationConfig {
+                        reg_def: &stored_rev_def.public,
+                        reg_def_private: &stored_rev_def.private,
+                        registry_idx: rev_idx,
+                        tails_reader: tr,
+                    }),
+                    Some(RevocationRegistryId::new_unchecked(rev_reg_id)),
+                )
+            }
+            None => (None, None),
+        };
+
+        let issue_cred = issuer::create_credential(
+            &ledger
+                .cred_defs
+                .get(&CredentialDefinitionId::new_unchecked(cred_def_id))
+                .unwrap(),
+            &issuer_wallet.cred_defs[cred_def_id].private,
+            offer,
+            cred_request,
+            cred_values.into(),
+            rev_id,
+            revocation_list,
+            rev_config,
+        )
+        .expect("Error creating credential");
+
+        issue_cred
+    }
+
+    // prover requests and gets credential stored in their wallets
+    // This updates ledger on revocation reg also
+    pub fn issuer_create_credential_and_store_in_prover_wallet(
+        &mut self,
+        issuer_id: &'static str,
+        prover_id: &'static str,
+        values: &'a IsserValues,
+        time_prev_rev_reg: u64,
+        time_new_rev_reg: u64,
+    ) {
+        for (cred_def_id, (_, cred_values, _, rev_reg_id, rev_idx)) in values.iter() {
+            let offer = &self.prover_wallets[prover_id].cred_offers[cred_def_id];
+            let cred_def = self
+                .ledger
+                .cred_defs
+                .get(&CredentialDefinitionId::new_unchecked(cred_def_id.clone()))
+                .unwrap();
+            // Prover creates a Credential Request
+            let cred_req_data = prover::create_credential_request(
+                Some(prover_id),
+                &cred_def,
+                &self.prover_wallets[prover_id].master_secret,
+                "default",
+                &offer,
+            )
+            .expect("Error creating credential request");
+
+            // Issuer creates a credential
+            let mut recv_cred = self.issuer_create_credential(
+                &self.issuer_wallets[issuer_id],
+                &self.ledger,
+                &cred_req_data.0,
+                &offer,
+                *rev_reg_id,
+                cred_def_id,
+                cred_values,
+                time_prev_rev_reg,
+                *rev_idx,
+            );
+
+            let rev_def = self.issuer_wallets[issuer_id]
+                .rev_defs
+                .get(*rev_reg_id)
+                .map(|e| &e.public);
+
+            // prover processes it
+            prover::process_credential(
+                &mut recv_cred,
+                &cred_req_data.1,
+                &self.prover_wallets[prover_id].master_secret,
+                &cred_def,
+                rev_def,
+            )
+            .expect("Error processing credential");
+
+            // Update prover wallets and ledger with new revocation status list
+            let pw = self.prover_wallets.get_mut(prover_id).unwrap();
+            pw.cred_reqs.push(cred_req_data);
+            pw.credentials.push(recv_cred);
+
+            if let Some(rev_def) = rev_def {
+                let list = self
+                    .ledger
+                    .revcation_list
+                    .get(*rev_reg_id)
+                    .unwrap()
+                    .get(&time_prev_rev_reg)
+                    .unwrap();
+
+                let updated_list = issuer::update_revocation_status_list(
+                    Some(time_new_rev_reg),
+                    Some(BTreeSet::from([*rev_idx])),
+                    None,
+                    Some(rev_def),
+                    list,
+                )
+                .unwrap();
+
+                let map = self.ledger.revcation_list.get_mut(&*rev_reg_id).unwrap();
+                map.insert(time_new_rev_reg, updated_list);
+            }
+        }
+    }
+
+    pub fn prover_creates_revocation_states(
+        &mut self,
+        prover_id: &'static str,
+        time_to_update_to: u64,
+    ) {
+        let mut rev_states = self.prover_wallets[prover_id].rev_states.clone();
+        for cred in &self.prover_wallets[prover_id].credentials {
+            if let Some(id) = &cred.rev_reg_id {
+                let rev_status_list = self
+                    .ledger
+                    .revcation_list
+                    .get(id.to_string().as_str())
+                    .unwrap()
+                    .get(&time_to_update_to)
+                    .unwrap();
+
+                let state = prover::create_or_update_revocation_state_with_witness(
+                    cred.witness.as_ref().unwrap().clone(),
+                    rev_status_list,
+                    time_to_update_to,
+                )
+                .unwrap();
+
+                // this overwrites the rev_state as there should only just be one that works
+                rev_states.insert(id.clone(), (Some(state), Some(time_to_update_to)));
+            };
+        }
+        self.prover_wallets.get_mut(prover_id).unwrap().rev_states = rev_states;
+    }
+
+    pub fn prover_creates_presentation(
+        &self,
+        prover_id: &'static str,
+        prover_values: ProverValues,
+        self_attested: HashMap<String, String>,
+        req: &PresentationRequest,
+    ) -> Presentation {
+        let schemas: HashMap<&SchemaId, &Schema> = HashMap::from_iter(self.ledger.schemas.iter());
+        let cred_defs: HashMap<&CredentialDefinitionId, &CredentialDefinition> =
+            HashMap::from_iter(self.ledger.cred_defs.iter());
+
+        let mut present = PresentCredentials::default();
+        for cred in self.prover_wallets[prover_id].credentials.iter() {
+            let values = prover_values
+                .get(cred.cred_def_id.to_string().as_str())
+                .unwrap();
+            {
+                let (rev_state, timestamp) = match &cred.rev_reg_id {
+                    Some(id) => self.prover_wallets[prover_id].rev_states.get(&id).unwrap(),
+                    None => &(None, None),
+                };
+                let mut cred1 = present.add_credential(cred, *timestamp, rev_state.as_ref());
+                for a in &values.0 {
+                    cred1.add_requested_attribute(a.clone(), true);
+                }
+                for p in &values.1 {
+                    cred1.add_requested_predicate(p.clone());
+                }
+            }
+        }
+
+        let presentation = prover::create_presentation(
+            req,
+            present,
+            Some(self_attested.clone()),
+            &self.prover_wallets[prover_id].master_secret,
+            &schemas,
+            &cred_defs,
+        )
+        .expect("Error creating presentation");
+
+        presentation
+    }
+}

--- a/anoncreds/tests/utils/mod.rs
+++ b/anoncreds/tests/utils/mod.rs
@@ -1,1 +1,4 @@
 pub mod anoncreds;
+pub mod mock;
+
+pub use mock::{IsserValues, Mock, ProverValues};


### PR DESCRIPTION
Note: the previous `CredentialRevocationConfig` struct used `RevocationRegistry` and had to be removed in this PR. 