### PR TITLE
fix(js): missing export and return type

### DIFF
--- a/wrappers/javascript/anoncreds-shared/src/api/Presentation.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/Presentation.ts
@@ -44,7 +44,6 @@ export type CreatePresentationOptions = {
 }
 
 export type VerifyPresentationOptions = {
-  presentation: Presentation
   presentationRequest: PresentationRequest
   schemas: Record<string, Schema>
   credentialDefinitions: Record<string, CredentialDefinition>
@@ -100,7 +99,7 @@ export class Presentation extends AnoncredsObject {
       : undefined
 
     return anoncreds.verifyPresentation({
-      presentation: options.presentation.handle,
+      presentation: this.handle,
       presentationRequest: options.presentationRequest.handle,
       schemas: schemas.map((object) => object.handle),
       schemaIds,

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
@@ -33,7 +33,7 @@ export class RevocationRegistryDefinition extends AnoncredsObject {
   }
 
   public static load(json: string) {
-    anoncreds.credentialFromJson({ json })
+    return new RevocationRegistryDefinition(anoncreds.revocationRegistryDefinitionFromJson({ json }).handle)
   }
 
   public getId() {

--- a/wrappers/javascript/anoncreds-shared/src/api/index.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/index.ts
@@ -16,4 +16,3 @@ export * from './RevocationRegistryDefinition'
 export * from './RevocationRegistryDefinitionPrivate'
 export * from './RevocationRegistryDelta'
 export * from './RevocationStatusList'
-

--- a/wrappers/javascript/anoncreds-shared/src/api/index.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/index.ts
@@ -15,3 +15,5 @@ export * from './RevocationRegistry'
 export * from './RevocationRegistryDefinition'
 export * from './RevocationRegistryDefinitionPrivate'
 export * from './RevocationRegistryDelta'
+export * from './RevocationStatusList'
+


### PR DESCRIPTION
Some minor fixes in JavaScript wrapper:

- Remove the need of passing a `Presentation` instance in `verify`, as it is an instance method and can get the handle by itself
- Expose `RevocationStatusList`
- Fix `RevocationRegistryDefinition.load` method