### PR TITLE
fix(js): proverDid optional in Credential Request

### DIFF
--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -134,7 +134,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
   }
 
   public createCredentialRequest(options: {
-    proverDid: string
+    proverDid?: string
     credentialDefinition: ObjectHandle
     masterSecret: ObjectHandle
     masterSecretId: string

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -48,7 +48,7 @@ export interface NativeBindings {
   createCredentialOffer(options: { schemaId: string; credentialDefinitionId: string; keyProof: number }): _Handle
 
   createCredentialRequest(options: {
-    proverDid: string
+    proverDid?: string
     credentialDefinition: number
     masterSecret: number
     masterSecretId: string

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRequest.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRequest.ts
@@ -8,7 +8,7 @@ import { anoncreds } from '../register'
 import { CredentialRequestMetadata } from './CredentialRequestMetadata'
 
 export type CreateCredentialRequestOptions = {
-  proverDid: string
+  proverDid?: string
   credentialDefinition: CredentialDefinition
   masterSecret: MasterSecret
   masterSecretId: string


### PR DESCRIPTION
Since #57, prover_did in Credential Request is optional and some parts of the wrappers have been updated accordingly. But there were some missing changes in interfaces for both Node.JS and React Native wrappers that are updated here.

Signed-off-by: Ariel Gentile <gentilester@gmail.com>