### PR TITLE
fix(js): added casting and fixed RN bindings

### DIFF
--- a/wrappers/javascript/anoncreds-nodejs/src/ffi/structures.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/ffi/structures.ts
@@ -70,7 +70,7 @@ export const CredentialEntryListStruct = CStruct({
 export const CredentialProveStruct = CStruct({
   entry_idx: FFI_INT64,
   referent: FFI_STRING,
-  is_predictable: FFI_INT8,
+  is_predicate: FFI_INT8,
   reveal: FFI_INT8,
 })
 

--- a/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
@@ -449,7 +449,7 @@ describe('bindings', () => {
 
     const revocationState = anoncreds.createOrUpdateRevocationState({
       revocationRegistryDefinition,
-      oldRevocationStatusList: revocationStatusList,
+      revocationStatusList,
       revocationRegistryIndex,
       tailsPath,
     })

--- a/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
@@ -104,7 +104,7 @@ describe('bindings', () => {
       tag: 'TAG',
     })
 
-    const { revocationRegistryDefinition: registryDefinition } = anoncreds.createRevocationRegistryDef({
+    const { revocationRegistryDefinition } = anoncreds.createRevocationRegistryDefinition({
       credentialDefinitionId: 'mock:uri',
       credentialDefinition,
       issuerId: 'mock:uri',
@@ -114,12 +114,12 @@ describe('bindings', () => {
     })
 
     const maximumCredentialNumber = anoncreds.revocationRegistryDefinitionGetAttribute({
-      objectHandle: registryDefinition,
+      objectHandle: revocationRegistryDefinition,
       name: 'max_cred_num',
     })
 
     expect(maximumCredentialNumber).toEqual('100')
-    const json = anoncreds.getJson({ objectHandle: registryDefinition })
+    const json = anoncreds.getJson({ objectHandle: revocationRegistryDefinition })
     expect(JSON.parse(json)).toEqual(
       expect.objectContaining({
         credDefId: 'mock:uri',
@@ -245,16 +245,15 @@ describe('bindings', () => {
       tag: 'TAG',
     })
 
-    const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } = anoncreds.createRevocationRegistryDef(
-      {
+    const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } =
+      anoncreds.createRevocationRegistryDefinition({
         credentialDefinitionId: 'mock:uri',
         credentialDefinition,
         issuerId: 'mock:uri',
         tag: 'some_tag',
         revocationRegistryType: 'CL_ACCUM',
         maximumCredentialNumber: 10,
-      }
-    )
+      })
 
     const tailsPath = anoncreds.revocationRegistryDefinitionGetAttribute({
       objectHandle: revocationRegistryDefinition,
@@ -378,16 +377,15 @@ describe('bindings', () => {
       tag: 'TAG',
     })
 
-    const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } = anoncreds.createRevocationRegistryDef(
-      {
+    const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } =
+      anoncreds.createRevocationRegistryDefinition({
         credentialDefinitionId: 'mock:uri',
         credentialDefinition,
         issuerId: 'mock:uri',
         tag: 'some_tag',
         revocationRegistryType: 'CL_ACCUM',
         maximumCredentialNumber: 10,
-      }
-    )
+      })
 
     const tailsPath = anoncreds.revocationRegistryDefinitionGetAttribute({
       objectHandle: revocationRegistryDefinition,
@@ -451,7 +449,7 @@ describe('bindings', () => {
 
     const revocationState = anoncreds.createOrUpdateRevocationState({
       revocationRegistryDefinition,
-      revocationStatusList,
+      oldRevocationStatusList: revocationStatusList,
       revocationRegistryIndex,
       tailsPath,
     })

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -6,6 +6,8 @@ using namespace turboModuleUtility;
 
 namespace anoncreds {
 
+// ===== GENERAL =====
+
 jsi::Value version(jsi::Runtime &rt, jsi::Object options) {
   return jsi::String::createFromAscii(rt, anoncreds_version());
 };
@@ -17,6 +19,170 @@ jsi::Value getCurrentError(jsi::Runtime &rt, jsi::Object options) {
 
   return jsi::String::createFromAscii(rt, errorJsonP);
 };
+
+jsi::Value getJson(jsi::Runtime &rt, jsi::Object options) {
+  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
+
+  ByteBuffer resultP;
+
+  ErrorCode code = anoncreds_object_get_json(handle, &resultP);
+  handleError(rt, code);
+
+  return jsi::String::createFromUtf8(rt, resultP.data, resultP.len);
+};
+
+jsi::Value getTypeName(jsi::Runtime &rt, jsi::Object options) {
+  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
+
+  const char *resultP;
+
+  ErrorCode code = anoncreds_object_get_type_name(handle, &resultP);
+  handleError(rt, code);
+
+  return jsi::String::createFromAscii(rt, resultP);
+};
+
+jsi::Value setDefaultLogger(jsi::Runtime &rt, jsi::Object options) {
+  anoncreds_set_default_logger();
+  return jsi::Value::null();
+};
+
+jsi::Value objectFree(jsi::Runtime &rt, jsi::Object options) {
+  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
+
+  anoncreds_object_free(handle);
+
+  return jsi::Value::null();
+};
+
+// ===== META =====
+
+jsi::Value createMasterSecret(jsi::Runtime &rt, jsi::Object options) {
+  ObjectHandle masterSecretP;
+
+  ErrorCode code = anoncreds_create_master_secret(&masterSecretP);
+  handleError(rt, code);
+
+  return jsi::Value(int(masterSecretP));
+};
+
+jsi::Value generateNonce(jsi::Runtime &rt, jsi::Object options) {
+  const char *nonceP;
+
+  ErrorCode code = anoncreds_generate_nonce(&nonceP);
+  handleError(rt, code);
+
+  return jsi::String::createFromAscii(rt, nonceP);
+};
+
+// ===== Anoncreds Objects =====
+
+jsi::Value createSchema(jsi::Runtime &rt, jsi::Object options) {
+  auto name = jsiToValue<std::string>(rt, options, "name");
+  auto version = jsiToValue<std::string>(rt, options, "version");
+  auto issuerId = jsiToValue<std::string>(rt, options, "issuerId");
+  auto attributeNames = jsiToValue<FfiStrList>(rt, options, "attributeNames");
+
+  ObjectHandle resultP;
+
+  ErrorCode code =
+      anoncreds_create_schema(name.c_str(), version.c_str(), issuerId.c_str(),
+                              attributeNames, &resultP);
+  handleError(rt, code);
+
+  return jsi::Value(int(resultP));
+};
+
+jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
+  auto schemaId = jsiToValue<std::string>(rt, options, "schemaId");
+  auto schema = jsiToValue<ObjectHandle>(rt, options, "schema");
+  auto credentialDefinitionId =
+      jsiToValue<std::string>(rt, options, "credentialDefinintionId");
+  auto tag = jsiToValue<std::string>(rt, options, "tag");
+  auto issuerId = jsiToValue<std::string>(rt, options, "issuerId");
+  auto signatureType = jsiToValue<std::string>(rt, options, "signatureType");
+  auto supportRevocation = jsiToValue<int8_t>(rt, options, "supportRevocation");
+
+  ObjectHandle credentialDefinitionP;
+  ObjectHandle credentialDefinitionPrivateP;
+  ObjectHandle keyProofP;
+
+  ErrorCode code = anoncreds_create_credential_definition(
+      schemaId.c_str(), schema, tag.c_str(), issuerId.c_str(),
+      signatureType.c_str(), supportRevocation, &credentialDefinitionP,
+      &credentialDefinitionPrivateP, &keyProofP);
+  handleError(rt, code);
+
+  jsi::Object object = jsi::Object(rt);
+  object.setProperty(rt, "credentialDefinition", int(credentialDefinitionP));
+  object.setProperty(rt, "credentialDefinitionPrivate",
+                     int(credentialDefinitionPrivateP));
+  object.setProperty(rt, "keyProof", int(keyProofP));
+  return object;
+};
+
+// ===== PROOFS =====
+
+jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
+  auto presentationRequest =
+      jsiToValue<ObjectHandle>(rt, options, "presentationRequest");
+  auto credentials =
+      jsiToValue<FfiList_FfiCredentialEntry>(rt, options, "credentials");
+  auto credentialsProve =
+      jsiToValue<FfiList_FfiCredentialProve>(rt, options, "credentialsProve");
+  auto selfAttestedNames =
+      jsiToValue<FfiStrList>(rt, options, "selfAttestedNames");
+  auto selfAttestedValues =
+      jsiToValue<FfiStrList>(rt, options, "selfAttestedValues");
+  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSercet");
+  auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
+  auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
+  auto credentialDefinitions =
+      jsiToValue<FfiList_ObjectHandle>(rt, options, "credentialDefinitions");
+  auto credentialDefinitionids =
+      jsiToValue<FfiList_FfiStr>(rt, options, "credentialDefinitionIds");
+
+  ObjectHandle presentationP;
+
+  ErrorCode code = anoncreds_create_presentation(
+      presentationRequest, credentials, credentialsProve, selfAttestedNames,
+      selfAttestedValues, masterSecret, schemas, schemaIds,
+      credentialDefinitions, credentialDefinitionids, &presentationP);
+  handleError(rt, code);
+
+  return jsi::Value(int(presentationP));
+};
+
+jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options) {
+  auto presentation = jsiToValue<ObjectHandle>(rt, options, "presentation");
+  auto presentationRequest =
+      jsiToValue<ObjectHandle>(rt, options, "presentationRequest");
+  auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
+  auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
+  auto credentialDefinitions =
+      jsiToValue<FfiList_ObjectHandle>(rt, options, "credentialDefinitions");
+  auto credentialDefinitionIds =
+      jsiToValue<FfiList_FfiStr>(rt, options, "credentialDefinitionIds");
+  auto revocationRegistryDefinitions = jsiToValue<FfiList_ObjectHandle>(
+      rt, options, "revocationRegistryDefinitions");
+  auto revocationRegistryDefinitionIds = jsiToValue<FfiList_FfiStr>(
+      rt, options, "revocationRegistryDefinitionIds");
+  auto revocationStatusLists =
+      jsiToValue<FfiList_ObjectHandle>(rt, options, "revocationStatusLists");
+
+  int8_t resultP;
+
+  ErrorCode code = anoncreds_verify_presentation(
+      presentation, presentationRequest, schemas, schemaIds,
+      credentialDefinitions, credentialDefinitionIds,
+      revocationRegistryDefinitions, revocationRegistryDefinitionIds,
+      revocationStatusLists, &resultP);
+  handleError(rt, code);
+
+  return jsi::Value(int(resultP));
+};
+
+// ===== CREDENTIALS =====
 
 jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
   auto credentialDefinition =
@@ -48,34 +214,6 @@ jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
   handleError(rt, code);
 
   return jsi::Value(int(credP));
-};
-
-jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
-  auto schemaId = jsiToValue<std::string>(rt, options, "schemaId");
-  auto schema = jsiToValue<ObjectHandle>(rt, options, "schema");
-  auto credentialDefinitionId =
-      jsiToValue<std::string>(rt, options, "credentialDefinintionId");
-  auto tag = jsiToValue<std::string>(rt, options, "tag");
-  auto issuerId = jsiToValue<std::string>(rt, options, "issuerId");
-  auto signatureType = jsiToValue<std::string>(rt, options, "signatureType");
-  auto supportRevocation = jsiToValue<int8_t>(rt, options, "supportRevocation");
-
-  ObjectHandle credentialDefinitionP;
-  ObjectHandle credentialDefinitionPrivateP;
-  ObjectHandle keyProofP;
-
-  ErrorCode code = anoncreds_create_credential_definition(
-      schemaId.c_str(), schema, tag.c_str(), issuerId.c_str(),
-      signatureType.c_str(), supportRevocation, &credentialDefinitionP,
-      &credentialDefinitionPrivateP, &keyProofP);
-  handleError(rt, code);
-
-  jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "credentialDefinition", int(credentialDefinitionP));
-  object.setProperty(rt, "credentialDefinitionPrivate",
-                     int(credentialDefinitionPrivateP));
-  object.setProperty(rt, "keyProof", int(keyProofP));
-  return object;
 };
 
 jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options) {
@@ -116,14 +254,53 @@ jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options) {
   return object;
 };
 
-jsi::Value createMasterSecret(jsi::Runtime &rt, jsi::Object options) {
-  ObjectHandle masterSecretP;
+jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options) {
+  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
+  auto name = jsiToValue<std::string>(rt, options, "name");
 
-  ErrorCode code = anoncreds_create_master_secret(&masterSecretP);
+  const char *resultP;
+
+  ErrorCode code =
+      anoncreds_credential_get_attribute(handle, name.c_str(), &resultP);
   handleError(rt, code);
 
-  return jsi::Value(int(masterSecretP));
+  return jsi::String::createFromAscii(rt, resultP);
 };
+
+jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
+  auto attributeRawValues =
+      jsiToValue<FfiList_FfiStr>(rt, options, "attributeRawValues");
+
+  const char *resultP;
+
+  ErrorCode code =
+      anoncreds_encode_credential_attributes(attributeRawValues, &resultP);
+  handleError(rt, code);
+
+  return jsi::String::createFromAscii(rt, resultP);
+};
+
+jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
+  auto credential = jsiToValue<ObjectHandle>(rt, options, "credential");
+  auto credentialRequestMetadata =
+      jsiToValue<ObjectHandle>(rt, options, "credentialRequestMetadata");
+  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSercet");
+  auto credentialDefinition =
+      jsiToValue<ObjectHandle>(rt, options, "credentialDefinition");
+  auto revocationRegistryDefinition =
+      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition");
+
+  ObjectHandle credentialP;
+
+  ErrorCode code = anoncreds_process_credential(
+      credential, credentialRequestMetadata, masterSecret, credentialDefinition,
+      revocationRegistryDefinition, &credentialP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialP));
+};
+
+// ===== REVOCATION =====
 
 jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt,
                                          jsi::Object options) {
@@ -139,7 +316,7 @@ jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt,
   auto oldRevocationStatusList =
       jsiToValue<ObjectHandle>(rt, options, "oldRevocationStatusList");
 
-  ObjectHandle revStateP;
+  ObjectHandle revocationStateP;
 
   ErrorCode code = anoncreds_create_or_update_revocation_state(
       revocationRegistryDefinition, revocationStatusList,
@@ -147,38 +324,60 @@ jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt,
       oldRevocationStatusList, &revStateP);
   handleError(rt, code);
 
-  return jsi::Value(int(revStateP));
+  return jsi::Value(int(revocationStateP));
 };
 
-jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
-  auto presentationRequest =
-      jsiToValue<ObjectHandle>(rt, options, "presentationRequest");
-  auto credentials =
-      jsiToValue<FfiList_FfiCredentialEntry>(rt, options, "credentials");
-  auto credentialsProve =
-      jsiToValue<FfiList_FfiCredentialProve>(rt, options, "credentialsProve");
-  auto selfAttestedNames =
-      jsiToValue<FfiStrList>(rt, options, "selfAttestedNames");
-  auto selfAttestedValues =
-      jsiToValue<FfiStrList>(rt, options, "selfAttestedValues");
-  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSercet");
-  auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
-  auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
-  auto credentialDefinitions =
-      jsiToValue<FfiList_ObjectHandle>(rt, options, "credentialDefinitions");
-  auto credentialDefinitionids =
-      jsiToValue<FfiList_FfiStr>(rt, options, "credentialDefinitionIds");
+jsi::value createRevocationStatusList(jsi::Runtime &rt, jsi::Object options) {
+  auto revocationRegistryDefinitionid =
+      jsiToValue<std::string>(rt, options, "revocationRegistryDefinitionId");
+  auto revocationRegistryDefinition =
+      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition");
+  auto timestamp = jsiToValue<int64_t>(rt, options, "timestamp");
+  auto issuanceByDefault = jsiToValue<int8_t>(rt, options, "issuanceByDefault");
 
-  ObjectHandle presentationP;
+  ObjectHandle revocationStatusListP;
 
-  ErrorCode code = anoncreds_create_presentation(
-      presentationRequest, credentials, credentialsProve, selfAttestedNames,
-      selfAttestedValues, masterSecret, schemas, schemaIds,
-      credentialDefinitions, credentialDefinitionids, &presentationP);
+  ErrorCode code = anoncreds_create_revocation_status_list(
+      revocationRegistryDefinitionId, revocationRegistryDefinition, timestamp,
+      issuanceByDefault);
   handleError(rt, code);
 
-  return jsi::Value(int(presentationP));
-};
+  return jsi::Value(int(revocationStatusListP));
+}
+
+jsi::Value updateRevocationStatusList(jsi::Runtime &rt, jsi::Object options) {
+  auto timestamp = jsiToValue<int64_t>(rt, options, "timestamp");
+  auto issued = jsiToValue<FfiList_i32>(rt, options, "issued");
+  auto revoked = jsiToValue<FfiList_i32>(rt, options, "revoked");
+  auto revocationRegistryDefinition =
+      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition");
+  auto revocationStatusList =
+      jsiToValue<ObjectHandle>(rt, options, "revocationStatusList");
+
+  ObjectHandle newRevocationStatusListP;
+
+  ErrorCode code = anoncreds_update_revocation_status_list(
+      timestamp, issued, revoked, revocationRegistryDefinition,
+      revocationStatusList, &newRevocationStatusListP);
+  handleError(rt, code);
+
+  return jsi::Value(int(newRevocationStatusListP));
+}
+
+jsi::Value updateRevocationStatusListTimestampOnly(jsi::Runtime &rt,
+                                                   jsi::Object options) {
+  auto timestamp = jsiToValue<int64_t>(rt, options, "timestamp");
+  auto revocationStatusList =
+      jsiToValue<ObjectHandle>(rt, options, "revocationStatusList");
+
+  ObjectHandle newRevocationStatusListP;
+
+  ErrorCode code = anoncreds_update_revocation_status_list_timestamp_only(
+      timestamp, revocationStatusList, &newRevocationStatusListP);
+  handleError(rt, code);
+
+  return jsi::Value(int(newRevocationStatusListP));
+}
 
 jsi::Value createRevocationRegistryDefinition(jsi::Runtime &rt,
                                               jsi::Object options) {
@@ -208,99 +407,6 @@ jsi::Value createRevocationRegistryDefinition(jsi::Runtime &rt,
   return object;
 };
 
-jsi::Value createSchema(jsi::Runtime &rt, jsi::Object options) {
-  auto name = jsiToValue<std::string>(rt, options, "name");
-  auto version = jsiToValue<std::string>(rt, options, "version");
-  auto issuerId = jsiToValue<std::string>(rt, options, "issuerId");
-  auto attributeNames = jsiToValue<FfiStrList>(rt, options, "attributeNames");
-
-  ObjectHandle resultP;
-
-  ErrorCode code =
-      anoncreds_create_schema(name.c_str(), version.c_str(), issuerId.c_str(),
-                              attributeNames, &resultP);
-  handleError(rt, code);
-
-  return jsi::Value(int(resultP));
-};
-
-jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options) {
-  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
-  auto name = jsiToValue<std::string>(rt, options, "name");
-
-  const char *resultP;
-
-  ErrorCode code =
-      anoncreds_credential_get_attribute(handle, name.c_str(), &resultP);
-  handleError(rt, code);
-
-  return jsi::String::createFromAscii(rt, resultP);
-};
-
-jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
-  auto attributeRawValues =
-      jsiToValue<FfiList_FfiStr>(rt, options, "attributeRawValues");
-
-  const char *resultP;
-
-  ErrorCode code =
-      anoncreds_encode_credential_attributes(attributeRawValues, &resultP);
-  handleError(rt, code);
-
-  return jsi::String::createFromAscii(rt, resultP);
-};
-
-jsi::Value generateNonce(jsi::Runtime &rt, jsi::Object options) {
-  const char *nonceP;
-
-  ErrorCode code = anoncreds_generate_nonce(&nonceP);
-  handleError(rt, code);
-
-  return jsi::String::createFromAscii(rt, nonceP);
-};
-
-jsi::Value getJson(jsi::Runtime &rt, jsi::Object options) {
-  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
-
-  ByteBuffer resultP;
-
-  ErrorCode code = anoncreds_object_get_json(handle, &resultP);
-  handleError(rt, code);
-
-  return jsi::String::createFromUtf8(rt, resultP.data, resultP.len);
-};
-
-jsi::Value getTypeName(jsi::Runtime &rt, jsi::Object options) {
-  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
-
-  const char *resultP;
-
-  ErrorCode code = anoncreds_object_get_type_name(handle, &resultP);
-  handleError(rt, code);
-
-  return jsi::String::createFromAscii(rt, resultP);
-};
-
-jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
-  auto credential = jsiToValue<ObjectHandle>(rt, options, "credential");
-  auto credentialRequestMetadata =
-      jsiToValue<ObjectHandle>(rt, options, "credentialRequestMetadata");
-  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSercet");
-  auto credentialDefinition =
-      jsiToValue<ObjectHandle>(rt, options, "credentialDefinition");
-  auto revocationRegistryDefinition =
-      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition");
-
-  ObjectHandle credentialP;
-
-  ErrorCode code = anoncreds_process_credential(
-      credential, credentialRequestMetadata, masterSecret, credentialDefinition,
-      revocationRegistryDefinition, &credentialP);
-  handleError(rt, code);
-
-  return jsi::Value(int(credentialP));
-};
-
 jsi::Value revocationRegistryDefinitionGetAttribute(jsi::Runtime &rt,
                                                     jsi::Object options) {
   auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
@@ -313,67 +419,6 @@ jsi::Value revocationRegistryDefinitionGetAttribute(jsi::Runtime &rt,
   handleError(rt, code);
 
   return jsi::String::createFromAscii(rt, resultP);
-};
-
-jsi::Value setDefaultLogger(jsi::Runtime &rt, jsi::Object options) {
-  anoncreds_set_default_logger();
-  return jsi::Value::null();
-};
-
-jsi::Value updateRevocationStatusList(jsi::Runtime &rt, jsi::Object options) {
-  auto timestamp = jsiToValue<int64_t>(rt, options, "timestamp");
-  auto issued = jsiToValue<FfiList_i32>(rt, options, "issued");
-  auto revoked = jsiToValue<FfiList_i32>(rt, options, "revoked");
-  auto revocationRegistryDefinition =
-      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition");
-  auto revocationStatusList =
-      jsiToValue<ObjectHandle>(rt, options, "revocationStatusList");
-
-  ObjectHandle newRevocationStatusListP;
-
-  ErrorCode code = anoncreds_update_revocation_status_list(
-      timestamp, issued, revoked, revocationRegistryDefinition,
-      revocationStatusList, &newRevocationStatusListP);
-  handleError(rt, code);
-
-  return jsi::Value(int(newRevocationStatusListP));
-}
-
-jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options) {
-  auto presentation = jsiToValue<ObjectHandle>(rt, options, "presentation");
-  auto presentationRequest =
-      jsiToValue<ObjectHandle>(rt, options, "presentationRequest");
-  auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
-  auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
-  auto credentialDefinitions =
-      jsiToValue<FfiList_ObjectHandle>(rt, options, "credentialDefinitions");
-  auto credentialDefinitionIds =
-      jsiToValue<FfiList_FfiStr>(rt, options, "credentialDefinitionIds");
-  auto revocationRegistryDefinitions = jsiToValue<FfiList_ObjectHandle>(
-      rt, options, "revocationRegistryDefinitions");
-  auto revocationRegistryDefinitionIds = jsiToValue<FfiList_FfiStr>(
-      rt, options, "revocationRegistryDefinitionIds");
-  auto revocationStatusLists =
-      jsiToValue<FfiList_ObjectHandle>(rt, options, "revocationStatusLists");
-
-  int8_t resultP;
-
-  ErrorCode code = anoncreds_verify_presentation(
-      presentation, presentationRequest, schemas, schemaIds,
-      credentialDefinitions, credentialDefinitionIds,
-      revocationRegistryDefinitions, revocationRegistryDefinitionIds,
-      revocationStatusLists, &resultP);
-  handleError(rt, code);
-
-  return jsi::Value(int(resultP));
-};
-
-jsi::Value objectFree(jsi::Runtime &rt, jsi::Object options) {
-  auto handle = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
-
-  anoncreds_object_free(handle);
-
-  return jsi::Value::null();
 };
 
 } // namespace anoncreds

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
@@ -8,29 +8,43 @@ using namespace facebook;
 
 namespace anoncreds {
 
+// General
 jsi::Value version(jsi::Runtime &rt, jsi::Object options);
 jsi::Value getCurrentError(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createMasterSecret(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options);
-jsi::Value createRevocationRegistryDefinition(jsi::Runtime &rt,
-                                              jsi::Object options);
-jsi::Value createSchema(jsi::Runtime &rt, jsi::Object options);
-jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options);
-jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options);
-jsi::Value generateNonce(jsi::Runtime &rt, jsi::Object options);
 jsi::Value getJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value getTypeName(jsi::Runtime &rt, jsi::Object options);
+jsi::Value setDefaultLogger(jsi::Runtime &rt, jsi::Object options);
+jsi::Value objectFree(jsi::Runtime &rt, jsi::Object options);
+
+// Meta
+jsi::Value createMasterSecret(jsi::Runtime &rt, jsi::Object options);
+jsi::Value generateNonce(jsi::Runtime &rt, jsi::Object options);
+
+// Anoncreds Objects
+jsi::Value createSchema(jsi::Runtime &rt, jsi::Object options);
+jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options);
+
+// Proofs
+jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options);
+jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options);
+
+// Credentials
+jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options);
+jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options);
+jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options);
+jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options);
 jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options);
+
+// Revocation
+jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt, jsi::Object options);
+jsi::Value createRevocationStatusList(jsi::Runtime &rt, jsi::Object options);
+jsi::Value updateRevocationStatusList(jsi::Runtime &rt, jsi::Object options);
+jsi::Value updateRevocationStatusListTimestampOnly(jsi::Runtime &rt,
+                                                   jsi::Object options);
+jsi::Value createRevocationRegistryDefinition(jsi::Runtime &rt,
+                                              jsi::Object options);
 jsi::Value revocationRegistryDefinitionGetAttribute(jsi::Runtime &rt,
                                                     jsi::Object options);
-jsi::Value setDefaultLogger(jsi::Runtime &rt, jsi::Object options);
-jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options);
-jsi::Value updateRevocationStatusList(jsi::Runtime &rt, jsi::Object options);
-jsi::Value objectFree(jsi::Runtime &rt, jsi::Object options);
 
 } // namespace anoncreds

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -3,7 +3,6 @@ import type {
   NativeCredentialEntry,
   NativeCredentialProve,
   NativeCredentialRevocationConfig,
-  NativeRevocationEntry,
 } from '@hyperledger/anoncreds-shared'
 
 import { ObjectHandle } from '@hyperledger/anoncreds-shared'
@@ -15,27 +14,30 @@ export class ReactNativeAnoncreds implements Anoncreds {
   public createRevocationStatusList(options: {
     revocationRegistryDefinitionId: string
     revocationRegistryDefinition: ObjectHandle
-    timestamp?: number | undefined
+    timestamp?: number
     issuanceByDefault: boolean
   }): ObjectHandle {
-    throw new Error('Method not implemented.')
+    const handle = anoncredsReactNative.createRevocationStatusList(serializeArguments(options))
+    return new ObjectHandle(handle)
   }
 
   public updateRevocationStatusListTimestampOnly(options: {
     timestamp: number
-    currentList: ObjectHandle
+    currentRevocationStatusList: ObjectHandle
   }): ObjectHandle {
-    throw new Error('Method not implemented.')
+    const handle = anoncredsReactNative.updateRevocationStatusListTimestampOnly(serializeArguments(options))
+    return new ObjectHandle(handle)
   }
 
   public updateRevocationStatusList(options: {
-    timestamp?: number | undefined
-    issued?: number[] | undefined
-    revoked?: number[] | undefined
+    timestamp?: number
+    issued?: number[]
+    revoked?: number[]
     revocationRegistryDefinition: ObjectHandle
-    currentList: ObjectHandle
+    currentRevocationStatusList: ObjectHandle
   }): ObjectHandle {
-    throw new Error('Method not implemented.')
+    const handle = anoncredsReactNative.updateRevocationStatusList(serializeArguments(options))
+    return new ObjectHandle(handle)
   }
 
   public version(): string {
@@ -108,22 +110,6 @@ export class ReactNativeAnoncreds implements Anoncreds {
     return new ObjectHandle(handle)
   }
 
-  public revokeCredential(options: {
-    revocationRegistryDefinition: ObjectHandle
-    revocationRegistry: ObjectHandle
-    credentialRevocationIndex: number
-    tailsPath: string
-  }): { revocationRegistry: ObjectHandle; revocationRegistryDelta: ObjectHandle } {
-    const { revocationRegistry, revocationRegistryDelta } = anoncredsReactNative.revokeCredential(
-      serializeArguments(options)
-    )
-
-    return {
-      revocationRegistryDelta: new ObjectHandle(revocationRegistryDelta),
-      revocationRegistry: new ObjectHandle(revocationRegistry),
-    }
-  }
-
   public createCredentialOffer(options: {
     schemaId: string
     credentialDefinitionId: string
@@ -164,10 +150,17 @@ export class ReactNativeAnoncreds implements Anoncreds {
     schemas: Record<string, ObjectHandle>
     credentialDefinitions: Record<string, ObjectHandle>
   }): ObjectHandle {
-    // TODO
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const handle = anoncredsReactNative.createPresentation(serializeArguments(options))
+    const schemaKeys = Object.keys(options.schemas)
+    const schemaValues = Object.values(options.schemas).map((o) => o.handle)
+    const credentialDefinitionKeys = Object.keys(options.credentialDefinitions)
+    const credentialDefinitionValues = Object.values(options.credentialDefinitions).map((o) => o.handle)
+    const handle = anoncredsReactNative.createPresentation({
+      ...serializeArguments(options),
+      schemas: schemaValues,
+      schemaIds: schemaKeys,
+      credentialDefinitions: credentialDefinitionValues,
+      credentialDefinitionIds: credentialDefinitionKeys,
+    })
     return new ObjectHandle(handle)
   }
 
@@ -185,7 +178,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
     return anoncredsReactNative.verifyPresentation(serializeArguments(options))
   }
 
-  public createRevocationRegistryDef(options: {
+  public createRevocationRegistryDefinition(options: {
     credentialDefinition: ObjectHandle
     credentialDefinitionId: string
     tag: string
@@ -197,7 +190,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
     revocationRegistryDefinition: ObjectHandle
     revocationRegistryDefinitionPrivate: ObjectHandle
   } {
-    const { registryDefinition, registryDefinitionPrivate } = anoncredsReactNative.createRevocationRegistry(
+    const { registryDefinition, registryDefinitionPrivate } = anoncredsReactNative.createRevocationRegistryDefinition(
       serializeArguments(options)
     )
 
@@ -207,41 +200,13 @@ export class ReactNativeAnoncreds implements Anoncreds {
     }
   }
 
-  public updateRevocationRegistry(options: {
-    revocationRegistryDefinition: ObjectHandle
-    revocationRegistry: ObjectHandle
-    issued: number[]
-    revoked: number[]
-    tailsDirectoryPath: string
-  }): { revocationRegistry: ObjectHandle; revocationRegistryDelta: ObjectHandle } {
-    const { revocationRegistry, revocationRegistryDelta } = anoncredsReactNative.updateRevocationRegistry(
-      serializeArguments(options)
-    )
-
-    return {
-      revocationRegistryDelta: new ObjectHandle(revocationRegistryDelta),
-      revocationRegistry: new ObjectHandle(revocationRegistry),
-    }
-  }
-
-  public mergeRevocationRegistryDeltas(options: {
-    revocationRegistryDelta1: ObjectHandle
-    revocationRegistryDelta2: ObjectHandle
-  }): ObjectHandle {
-    const handle = anoncredsReactNative.mergeRevocationRegistryDeltas(serializeArguments(options))
-    return new ObjectHandle(handle)
-  }
-
   public createOrUpdateRevocationState(options: {
     revocationRegistryDefinition: ObjectHandle
-    revocationStatusList: ObjectHandle
     revocationRegistryIndex: number
     tailsPath: string
-    previousRevocationState?: ObjectHandle
+    revocationState?: number
+    oldRevocationStatusList?: ObjectHandle
   }): ObjectHandle {
-    // TODO
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     const handle = anoncredsReactNative.createOrUpdateRevocationState(serializeArguments(options))
     return new ObjectHandle(handle)
   }

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -1,7 +1,6 @@
 import type {
   NativeCredentialEntry,
   NativeCredentialProve,
-  NativeRevocationEntry,
   NativeCredentialRevocationConfig,
 } from '@hyperledger/anoncreds-shared'
 
@@ -13,6 +12,20 @@ export interface NativeBindings {
   getCurrentError(options: Record<never, never>): string
   generateNonce(options: Record<never, never>): string
   createSchema(options: { name: string; version: string; issuerId: string; attributeNames: string[] }): _Handle
+  createRevocationStatusList(options: {
+    revocationRegistryDefinitionId: string
+    revocationRegistryDefinition: _Handle
+    timestamp?: number
+    issuanceByDefault: number
+  }): _Handle
+  updateRevocationStatusList(options: {
+    timestamp?: number
+    issued?: number[]
+    revoked?: number[]
+    revocationRegistryDefinition: _Handle
+    currentRevocationStatusList: _Handle
+  }): _Handle
+  updateRevocationStatusListTimestampOnly(options: { timestamp: number; currentRevocationStatusList: _Handle }): _Handle
   createCredentialDefinition(options: {
     schemaId: string
     schema: number
@@ -38,15 +51,7 @@ export interface NativeBindings {
     credentialDefinition: number
     revocationRegistryDefinition?: number
   }): _Handle
-  revokeCredential(options: {
-    revocationRegistryDefinition: number
-    revocationRegistry: number
-    credentialRevocationIndex: number
-    tailsPath: string
-  }): { revocationRegistry: _Handle; revocationRegistryDelta: _Handle }
-
   createCredentialOffer(options: { schemaId: string; credentialDefinitionId: string; keyProof: number }): _Handle
-
   createCredentialRequest(options: {
     proverDid?: string
     credentialDefinition: number
@@ -54,19 +59,18 @@ export interface NativeBindings {
     masterSecretId: string
     credentialOffer: number
   }): { credentialRequest: _Handle; credentialRequestMetadata: _Handle }
-
   createMasterSecret(options: Record<never, never>): number
-
   createPresentation(options: {
     presentationRequest: number
     credentials: NativeCredentialEntry[]
     credentialsProve: NativeCredentialProve[]
     selfAttest: string
     masterSecret: number
+    schemaIds: string[]
     schemas: number[]
+    credentialDefinitionIds: string[]
     credentialDefinitions: number[]
   }): _Handle
-
   verifyPresentation(options: {
     presentation: number
     presentationRequest: number
@@ -78,8 +82,7 @@ export interface NativeBindings {
     revocationRegistryDefinitionIds?: string[]
     revocationStatusLists?: number[]
   }): boolean
-
-  createRevocationRegistry(options: {
+  createRevocationRegistryDefinition(options: {
     credentialDefinition: number
     credentialDefinitionId: string
     issuerId: string
@@ -93,27 +96,12 @@ export interface NativeBindings {
     registryEntry: _Handle
     registryInitDelta: _Handle
   }
-
-  updateRevocationRegistry(options: {
-    revocationRegistryDefinition: number
-    revocationRegistry: number
-    issued: number[]
-    revoked: number[]
-    tailsDirectoryPath: string
-  }): { revocationRegistry: _Handle; revocationRegistryDelta: _Handle }
-
-  mergeRevocationRegistryDeltas(options: {
-    revocationRegistryDelta1: number
-    revocationRegistryDelta2: number
-  }): _Handle
-
   createOrUpdateRevocationState(options: {
     revocationRegistryDefinition: number
-    revocationRegistryList: number
     revocationRegistryIndex: number
     tailsPath: string
-    revocationState: number
-    oldRevocationRegistryList: number
+    revocationState?: number
+    oldRevocationStatusList?: number
   }): _Handle
   presentationRequestFromJson(options: { json: string }): _Handle
   schemaGetAttribute(options: { objectHandle: number; name: string }): string

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -122,6 +122,7 @@ export interface Anoncreds {
 
   createOrUpdateRevocationState(options: {
     revocationRegistryDefinition: ObjectHandle
+    revocationStatusList: ObjectHandle
     revocationRegistryIndex: number
     tailsPath: string
     previousRevocationState?: ObjectHandle

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -107,7 +107,7 @@ export interface Anoncreds {
     revocationStatusLists?: ObjectHandle[]
   }): boolean
 
-  createRevocationRegistryDef(options: {
+  createRevocationRegistryDefinition(options: {
     credentialDefinition: ObjectHandle
     credentialDefinitionId: string
     issuerId: string
@@ -122,10 +122,10 @@ export interface Anoncreds {
 
   createOrUpdateRevocationState(options: {
     revocationRegistryDefinition: ObjectHandle
-    revocationStatusList: ObjectHandle
     revocationRegistryIndex: number
     tailsPath: string
     previousRevocationState?: ObjectHandle
+    oldRevocationStatusList?: ObjectHandle
   }): ObjectHandle
 
   createRevocationStatusList(options: {
@@ -135,14 +135,17 @@ export interface Anoncreds {
     issuanceByDefault: boolean
   }): ObjectHandle
 
-  updateRevocationStatusListTimestampOnly(options: { timestamp: number; currentList: ObjectHandle }): ObjectHandle
+  updateRevocationStatusListTimestampOnly(options: {
+    timestamp: number
+    currentRevocationStatusList: ObjectHandle
+  }): ObjectHandle
 
   updateRevocationStatusList(options: {
     timestamp?: number
     issued?: Array<number>
     revoked?: Array<number>
     revocationRegistryDefinition: ObjectHandle
-    currentList: ObjectHandle
+    currentRevocationStatusList: ObjectHandle
   }): ObjectHandle
 
   credentialGetAttribute(options: { objectHandle: ObjectHandle; name: string }): string

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
@@ -6,13 +6,16 @@ import { anoncreds } from '../register'
 
 export type CreateRevocationStateOptions = {
   revocationRegistryDefinition: RevocationRegistryDefinition
-  revocationRegistryStatusList: RevocationRegistryDelta
   revocationRegistryIndex: number
   tailsPath: string
+  oldRevocationStatusList?: RevocationRegistryDelta
   previousRevocationState?: CredentialRevocationState
 }
 
-export type UpdateRevocationStateOptions = CreateRevocationStateOptions
+export type UpdateRevocationStateOptions = Required<
+  Pick<CreateRevocationStateOptions, 'oldRevocationStatusList' | 'previousRevocationState'>
+> &
+  Omit<CreateRevocationStateOptions, 'oldRevocationStatusList' | 'previousRevocationState'>
 
 export class CredentialRevocationState extends AnoncredsObject {
   public static create(options: CreateRevocationStateOptions) {
@@ -21,8 +24,8 @@ export class CredentialRevocationState extends AnoncredsObject {
         revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
         revocationRegistryIndex: options.revocationRegistryIndex,
         tailsPath: options.tailsPath,
-        revocationStatusList: options.revocationRegistryStatusList.handle,
-        previousRevocationState: options.previousRevocationState?.handle,
+        oldRevocationStatusList: undefined,
+        previousRevocationState: undefined,
       }).handle
     )
   }
@@ -36,8 +39,8 @@ export class CredentialRevocationState extends AnoncredsObject {
       revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
       revocationRegistryIndex: options.revocationRegistryIndex,
       tailsPath: options.tailsPath,
-      revocationStatusList: options.revocationRegistryStatusList.handle,
-      previousRevocationState: options.previousRevocationState?.handle,
+      oldRevocationStatusList: options.oldRevocationStatusList.handle,
+      previousRevocationState: options.previousRevocationState.handle,
     })
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
@@ -1,11 +1,13 @@
 import type { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
 import type { RevocationRegistryDelta } from './RevocationRegistryDelta'
+import type { RevocationStatusList } from './RevocationStatusList'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export type CreateRevocationStateOptions = {
   revocationRegistryDefinition: RevocationRegistryDefinition
+  revocationStatusList: RevocationStatusList
   revocationRegistryIndex: number
   tailsPath: string
   oldRevocationStatusList?: RevocationRegistryDelta
@@ -22,6 +24,7 @@ export class CredentialRevocationState extends AnoncredsObject {
     return new CredentialRevocationState(
       anoncreds.createOrUpdateRevocationState({
         revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
+        revocationStatusList: options.revocationStatusList.handle,
         revocationRegistryIndex: options.revocationRegistryIndex,
         tailsPath: options.tailsPath,
         oldRevocationStatusList: undefined,
@@ -37,6 +40,7 @@ export class CredentialRevocationState extends AnoncredsObject {
   public update(options: UpdateRevocationStateOptions) {
     this.handle = anoncreds.createOrUpdateRevocationState({
       revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
+      revocationStatusList: options.revocationStatusList.handle,
       revocationRegistryIndex: options.revocationRegistryIndex,
       tailsPath: options.tailsPath,
       oldRevocationStatusList: options.oldRevocationStatusList.handle,

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
@@ -21,7 +21,7 @@ export class RevocationRegistryDefinition extends AnoncredsObject {
     const {
       revocationRegistryDefinition: registryDefinition,
       revocationRegistryDefinitionPrivate: registryDefinitionPrivate,
-    } = anoncreds.createRevocationRegistryDef({
+    } = anoncreds.createRevocationRegistryDefinition({
       ...options,
       credentialDefinition: options.credentialDefinition.handle,
     })

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
@@ -35,7 +35,7 @@ export class RevocationStatusList extends AnoncredsObject {
   public updateTimestamp(options: UpdateRevocationStatusListTimestampOptions) {
     const updatedRevocationStatusList = anoncreds.updateRevocationStatusListTimestampOnly({
       timestamp: options.timestamp,
-      currentList: this.handle,
+      currentRevocationStatusList: this.handle,
     })
 
     this.handle = updatedRevocationStatusList
@@ -45,7 +45,7 @@ export class RevocationStatusList extends AnoncredsObject {
     const updatedRevocationStatusList = anoncreds.updateRevocationStatusList({
       ...options,
       revocationRegistryDefinition: options.revocationRegstryDefinition.handle,
-      currentList: this.handle,
+      currentRevocationStatusList: this.handle,
     })
 
     this.handle = updatedRevocationStatusList


### PR DESCRIPTION
there might still be some minor issues with some properties being required by CPP but can be undefined by JS. I will fix this incrementally when we test AFJ for RN with Anoncreds.

I added quite a bit of casting to avoid the `@ts-ignore`. This should be cleaned up, but can be done later. It has to be done because ref-napi, struct-napi and array-napi create some funky non-interop types. 

I would like to fix this more generic so we can copy some code between all the shared modules and do it properly.

Signed-off-by: blu3beri <blu3beri@proton.me>
