### PR TITLE
fix: parameters when creating credentials without revocation

### DIFF
--- a/src/ffi/credential.rs
+++ b/src/ffi/credential.rs
@@ -125,7 +125,10 @@ pub extern "C" fn anoncreds_create_credential(
             cred_request.load()?.cast_ref()?,
             cred_values.into(),
             rev_reg_id,
-            rev_status_list.load()?.cast_ref().ok(),
+            rev_status_list.opt_load()?
+                .as_ref()
+                .map(AnonCredsObject::cast_ref)
+                .transpose()?,
             revocation_config
                 .as_ref()
                 .map(RevocationConfig::as_ref_config)

--- a/src/ffi/credential.rs
+++ b/src/ffi/credential.rs
@@ -125,7 +125,8 @@ pub extern "C" fn anoncreds_create_credential(
             cred_request.load()?.cast_ref()?,
             cred_values.into(),
             rev_reg_id,
-            rev_status_list.opt_load()?
+            rev_status_list
+                .opt_load()?
                 .as_ref()
                 .map(AnonCredsObject::cast_ref)
                 .transpose()?,

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -285,7 +285,7 @@ export class NodeJSAnoncreds implements Anoncreds {
 
     const credentialEntries = options.credentials.map((value) => {
       const { credential, timestamp, revocationState: rev_state } = serializeArguments(value)
-      return CredentialEntryStruct({ credential, timestamp, rev_state })
+      return CredentialEntryStruct({ credential, timestamp: timestamp ?? -1, rev_state: rev_state ?? 0 })
     })
 
     const credentialEntryList = CredentialEntryListStruct({

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -125,7 +125,6 @@ export class NodeJSAnoncreds implements Anoncreds {
       credentialOffer,
       credentialRequest,
       revocationRegistryId,
-      revocationStatusList,
     } = serializeArguments(options)
 
     const attributeNames = StringListStruct({
@@ -172,8 +171,8 @@ export class NodeJSAnoncreds implements Anoncreds {
       attributeRawValues as unknown as Buffer,
       attributeEncodedValues as unknown as Buffer,
       revocationRegistryId,
-      revocationStatusList ?? 0,
-      revocationConfiguration ? revocationConfiguration.ref().address() : 0,
+      options.revocationStatusList?.handle ?? 0,
+      revocationConfiguration?.ref().address() ?? 0,
       credentialPtr
     )
     handleError()
@@ -201,8 +200,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     credentialDefinition: ObjectHandle
     revocationRegistryDefinition?: ObjectHandle | undefined
   }): ObjectHandle {
-    const { credential, credentialRequestMetadata, masterSecret, credentialDefinition, revocationRegistryDefinition } =
-      serializeArguments(options)
+    const { credential, credentialRequestMetadata, masterSecret, credentialDefinition } = serializeArguments(options)
 
     const ret = allocatePointer()
 
@@ -211,7 +209,7 @@ export class NodeJSAnoncreds implements Anoncreds {
       credentialRequestMetadata,
       masterSecret,
       credentialDefinition,
-      revocationRegistryDefinition ?? 0,
+      options.revocationRegistryDefinition?.handle ?? 0,
       ret
     )
     handleError()
@@ -283,10 +281,13 @@ export class NodeJSAnoncreds implements Anoncreds {
   }): ObjectHandle {
     const { presentationRequest, masterSecret } = serializeArguments(options)
 
-    const credentialEntries = options.credentials.map((value) => {
-      const { credential, timestamp, revocationState: rev_state } = serializeArguments(value)
-      return CredentialEntryStruct({ credential, timestamp: timestamp ?? -1, rev_state: rev_state ?? 0 })
-    })
+    const credentialEntries = options.credentials.map((value) =>
+      CredentialEntryStruct({
+        credential: value.credential.handle,
+        timestamp: value.timestamp ?? -1,
+        rev_state: value.revocationState?.handle ?? 0,
+      })
+    )
 
     const credentialEntryList = CredentialEntryListStruct({
       count: credentialEntries.length,
@@ -301,7 +302,6 @@ export class NodeJSAnoncreds implements Anoncreds {
 
     const credentialProves = options.credentialsProve.map((value) => {
       const { entryIndex: entry_idx, isPredicate: is_predicate, reveal, referent } = serializeArguments(value)
-
       return CredentialProveStruct({ entry_idx, referent, is_predicate, reveal })
     })
 

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -145,7 +145,7 @@ export class NodeJSAnoncreds implements Anoncreds {
         })
       : undefined
 
-    let revocationConfiguration = CredRevInfoStruct()
+    let revocationConfiguration
     if (options.revocationConfiguration) {
       const {
         revocationRegistryDefinition: registryDefinition,
@@ -172,8 +172,8 @@ export class NodeJSAnoncreds implements Anoncreds {
       attributeRawValues as unknown as Buffer,
       attributeEncodedValues as unknown as Buffer,
       revocationRegistryId,
-      revocationStatusList,
-      revocationConfiguration.ref(),
+      revocationStatusList ?? 0,
+      revocationConfiguration ? revocationConfiguration.ref().address() : 0,
       credentialPtr
     )
     handleError()

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -211,7 +211,7 @@ export class NodeJSAnoncreds implements Anoncreds {
       credentialRequestMetadata,
       masterSecret,
       credentialDefinition,
-      revocationRegistryDefinition,
+      revocationRegistryDefinition ?? 0,
       ret
     )
     handleError()

--- a/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
@@ -1,11 +1,8 @@
-import { refType } from 'ref-napi'
-
 import {
   ByteBufferStruct,
   FFI_ERRORCODE,
   FFI_OBJECT_HANDLE,
   StringListStruct,
-  CredRevInfoStruct,
   FFI_OBJECT_HANDLE_PTR,
   FFI_STRING,
   FFI_INT8,

--- a/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
@@ -35,7 +35,7 @@ export const nativeBindings = {
       StringListStruct,
       FFI_STRING,
       FFI_OBJECT_HANDLE,
-      refType(CredRevInfoStruct),
+      FFI_OBJECT_HANDLE,
       FFI_OBJECT_HANDLE_PTR,
     ],
   ],

--- a/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
@@ -1,0 +1,331 @@
+import {
+  anoncreds,
+  Credential,
+  CredentialDefinition,
+  CredentialOffer,
+  CredentialRequest,
+  CredentialRevocationConfig,
+  CredentialRevocationState,
+  MasterSecret,
+  Presentation,
+  PresentationRequest,
+  RevocationRegistryDefinition,
+  RevocationStatusList,
+  Schema,
+} from '@hyperledger/anoncreds-shared'
+
+import { setup } from './utils'
+
+describe('API', () => {
+  beforeAll(() => setup())
+
+  test('create and verify presentation', () => {
+    const nonce = anoncreds.generateNonce()
+
+    const presentationRequest = PresentationRequest.load(
+      JSON.stringify({
+        nonce,
+        name: 'pres_req_1',
+        version: '0.1',
+        requested_attributes: {
+          attr1_referent: {
+            name: 'name',
+            issuer: 'mock:uri',
+          },
+          attr2_referent: {
+            name: 'sex',
+          },
+          attr3_referent: {
+            name: 'phone',
+          },
+          attr4_referent: {
+            names: ['name', 'height'],
+          },
+        },
+        requested_predicates: {
+          predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+        },
+        non_revoked: { from: 10, to: 200 },
+      })
+    )
+
+    const schema = Schema.create({
+      name: 'schema-1',
+      issuerId: 'mock:uri',
+      version: '1',
+      attributeNames: ['name', 'age', 'sex', 'height'],
+    })
+
+    const { credentialDefinition, keyCorrectnessProof, credentialDefinitionPrivate } = CredentialDefinition.create({
+      schemaId: 'mock:uri',
+      issuerId: 'mock:uri',
+      schema,
+      signatureType: 'CL',
+      supportRevocation: true,
+      tag: 'TAG',
+    })
+
+    const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } = RevocationRegistryDefinition.create({
+      credentialDefinitionId: 'mock:uri',
+      credentialDefinition,
+      issuerId: 'mock:uri',
+      tag: 'some_tag',
+      revocationRegistryType: 'CL_ACCUM',
+      maximumCredentialNumber: 10,
+    })
+
+    const tailsPath = revocationRegistryDefinition.getTailsLocation()
+
+    const timeCreateRevStatusList = 12
+    const revocationStatusList = RevocationStatusList.create({
+      timestamp: timeCreateRevStatusList,
+      issuanceByDefault: true,
+      revocationRegistryDefinition,
+      revocationRegistryDefinitionId: 'mock:uri',
+    })
+
+    const credentialOffer = CredentialOffer.create({
+      schemaId: 'mock:uri',
+      credentialDefinitionId: 'mock:uri',
+      keyCorrectnessProof,
+    })
+
+    const masterSecret = MasterSecret.create()
+    const masterSecretId = 'master secret id'
+
+    const { credentialRequestMetadata, credentialRequest } = CredentialRequest.create({
+      credentialDefinition,
+      masterSecret,
+      masterSecretId,
+      credentialOffer,
+    })
+
+    const credential = Credential.create({
+      credentialDefinition,
+      credentialDefinitionPrivate,
+      credentialOffer,
+      credentialRequest,
+      attributeRawValues: { name: 'Alex', height: '175', age: '28', sex: 'male' },
+      revocationRegistryId: 'mock:uri',
+      revocationStatusList,
+      revocationConfiguration: new CredentialRevocationConfig({
+        registryDefinition: revocationRegistryDefinition,
+        registryDefinitionPrivate: revocationRegistryDefinitionPrivate,
+        registryIndex: 9,
+        tailsPath,
+      }),
+    })
+
+    const credentialReceived = credential.process({
+      credentialDefinition,
+      credentialRequestMetadata,
+      masterSecret,
+      revocationRegistryDefinition,
+    })
+
+    const revocationRegistryIndex = credentialReceived.revocationRegistryIndex ?? 0
+
+    const revocationState = CredentialRevocationState.create({
+      revocationRegistryDefinition,
+      revocationStatusList,
+      revocationRegistryIndex,
+      tailsPath,
+    })
+
+    const presentation = Presentation.create({
+      presentationRequest,
+      credentials: [
+        {
+          credential: credentialReceived,
+          revocationState,
+          timestamp: timeCreateRevStatusList,
+        },
+      ],
+      credentialDefinitions: { 'mock:uri': credentialDefinition },
+      credentialsProve: [
+        {
+          entryIndex: 0,
+          isPredicate: false,
+          referent: 'attr1_referent',
+          reveal: true,
+        },
+        {
+          entryIndex: 0,
+          isPredicate: false,
+          referent: 'attr2_referent',
+          reveal: false,
+        },
+        {
+          entryIndex: 0,
+          isPredicate: false,
+          referent: 'attr4_referent',
+          reveal: true,
+        },
+        {
+          entryIndex: 0,
+          isPredicate: true,
+          referent: 'predicate1_referent',
+          reveal: true,
+        },
+      ],
+      masterSecret,
+      schemas: { 'mock:uri': schema },
+      selfAttest: { attr3_referent: '8-800-300' },
+    })
+
+    expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
+
+    const verify = Presentation.load(presentation.toJson()).verify({
+      presentationRequest,
+      schemas: { ['mock:uri']: schema },
+      credentialDefinitions: { ['mock:uri']: credentialDefinition },
+      revocationRegistryDefinitions: { ['mock:uri']: revocationRegistryDefinition },
+      revocationStatusLists: [revocationStatusList],
+    })
+
+    expect(verify).toBeTruthy()
+  })
+
+  test('create and verify presentation (no revocation use case)', () => {
+    const schema = Schema.create({
+      name: 'schema-1',
+      issuerId: 'mock:uri',
+      version: '1',
+      attributeNames: ['name', 'age', 'sex', 'height'],
+    })
+
+    const { credentialDefinition, keyCorrectnessProof, credentialDefinitionPrivate } = CredentialDefinition.create({
+      schemaId: 'mock:uri',
+      issuerId: 'mock:uri',
+      schema,
+      signatureType: 'CL',
+      supportRevocation: false,
+      tag: 'TAG',
+    })
+
+    const credentialOffer = CredentialOffer.create({
+      schemaId: 'mock:uri',
+      credentialDefinitionId: 'mock:uri',
+      keyCorrectnessProof,
+    })
+
+    const masterSecret = MasterSecret.create()
+    const masterSecretId = 'master secret id'
+
+    const { credentialRequestMetadata, credentialRequest } = CredentialRequest.create({
+      credentialDefinition,
+      masterSecret,
+      masterSecretId,
+      credentialOffer,
+    })
+
+    const credential = Credential.create({
+      credentialDefinition,
+      credentialDefinitionPrivate,
+      credentialOffer,
+      credentialRequest,
+      attributeRawValues: { name: 'Alex', height: '175', age: '28', sex: 'male' },
+    })
+
+    const credReceived = credential.process({
+      credentialDefinition,
+      credentialRequestMetadata,
+      masterSecret,
+    })
+
+    const credJson = credential.toJson()
+    expect(JSON.parse(credJson)).toEqual(
+      expect.objectContaining({
+        cred_def_id: 'mock:uri',
+        schema_id: 'mock:uri',
+      })
+    )
+
+    const credReceivedJson = credential.toJson()
+    expect(JSON.parse(credReceivedJson)).toEqual(
+      expect.objectContaining({
+        cred_def_id: 'mock:uri',
+        schema_id: 'mock:uri',
+      })
+    )
+    expect(JSON.parse(credReceivedJson)).toHaveProperty('signature')
+    expect(JSON.parse(credReceivedJson)).toHaveProperty('witness')
+
+    const nonce = anoncreds.generateNonce()
+
+    const presentationRequest = PresentationRequest.load(
+      JSON.stringify({
+        nonce,
+        name: 'pres_req_1',
+        version: '0.1',
+        requested_attributes: {
+          attr1_referent: {
+            name: 'name',
+            issuer: 'mock:uri',
+          },
+          attr2_referent: {
+            name: 'sex',
+          },
+          attr3_referent: {
+            name: 'phone',
+          },
+          attr4_referent: {
+            names: ['name', 'height'],
+          },
+        },
+        requested_predicates: {
+          predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+        },
+      })
+    )
+
+    const presentation = Presentation.create({
+      presentationRequest,
+      credentials: [
+        {
+          credential: credReceived,
+        },
+      ],
+      credentialDefinitions: { 'mock:uri': credentialDefinition },
+      credentialsProve: [
+        {
+          entryIndex: 0,
+          isPredicate: false,
+          referent: 'attr1_referent',
+          reveal: true,
+        },
+        {
+          entryIndex: 0,
+          isPredicate: false,
+          referent: 'attr2_referent',
+          reveal: false,
+        },
+        {
+          entryIndex: 0,
+          isPredicate: false,
+          referent: 'attr4_referent',
+          reveal: true,
+        },
+        {
+          entryIndex: 0,
+          isPredicate: true,
+          referent: 'predicate1_referent',
+          reveal: true,
+        },
+      ],
+      masterSecret,
+      schemas: { 'mock:uri': schema },
+      selfAttest: { attr3_referent: '8-800-300' },
+    })
+
+    expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
+
+    const verify = Presentation.load(presentation.toJson()).verify({
+      presentationRequest,
+      schemas: { ['mock:uri']: schema },
+      credentialDefinitions: { ['mock:uri']: credentialDefinition },
+    })
+
+    expect(verify).toBeTruthy()
+  })
+})

--- a/wrappers/javascript/anoncreds-nodejs/test/utils/initialize.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/utils/initialize.ts
@@ -1,9 +1,7 @@
 import { registerAnoncreds } from '@hyperledger/anoncreds-shared'
 
 import { NodeJSAnoncreds } from '../../src/NodeJSAnoncreds'
-import { nativeAnoncreds } from '../../src/library'
 
 export const setup = () => {
   registerAnoncreds({ lib: new NodeJSAnoncreds() })
-  nativeAnoncreds.anoncreds_set_default_logger()
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationConfig.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationConfig.ts
@@ -1,14 +1,11 @@
 import type { NativeCredentialRevocationConfig } from '../Anoncreds'
-import type { RevocationRegistry } from './RevocationRegistry'
 import type { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
 import type { RevocationRegistryDefinitionPrivate } from './RevocationRegistryDefinitionPrivate'
 
 export type CredentialRevocationConfigOptions = {
   registryDefinition: RevocationRegistryDefinition
   registryDefinitionPrivate: RevocationRegistryDefinitionPrivate
-  registry: RevocationRegistry
   registryIndex: number
-  registryUsed?: number[]
   tailsPath: string
 }
 


### PR DESCRIPTION
When attempting to create some credentials without any kind of revocation configuration, under JS I've noticed that it was not properly handling some optional parameters for creating and processing credentials:
- In `create_credential`, `revocationConfiguration` was sending a default CredRevInfoStruct, that library was not interpreting as null so it was throwing an error about missing tails file path
- Also in `create_credential`, JS wrapper was not accepting an empty  `revocationStatusList`. In addition, once solved, Rust part was throwing an 'Invalid object handle' error when trying to load the object as it was mandatory
- In `process_credential`, JS wrapper was not accepting an empty `revocationRegistryDefinition`

I'm not sure if the solutions implemented in this PR are completely correct, even if they seem to work fine. So please @whalelephant and @blu3beri (as the authors of this revocation stuff in Rust and FFI wrapper in JS) let me know about any suggestion you may have (or feel free to add some commits to this PR or even completely disregard it if it's too bad! :stuck_out_tongue: )