### PR TITLE
fix: python wrapper type hint tweaks

### DIFF
--- a/wrappers/python/anoncreds/types.py
+++ b/wrappers/python/anoncreds/types.py
@@ -10,7 +10,7 @@ class CredentialDefinition(bindings.AnoncredsObject):
     def create(
         cls,
         schema_id: str,
-        schema: Union[str, "Schema"],
+        schema: Union[dict, str, "Schema"],
         issuer_id: str,
         tag: str,
         signature_type: str,


### PR DESCRIPTION
This PR refines type hints in the python wrapper. These corrections make static type checkers like pyright/pylance happier.

I'll open this as a draft for now and add more commits as I run into type complaints from pyright.