### PR TITLE
update `ursa` to 0.3.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ serde_json = { version = "1.0", features = ["raw_value"]}
 sha2 = "0.10"
 tempfile = "3.1.0"
 thiserror = "1.0"
-ursa = { version = "=0.3.6", default-features = false, features = ["cl_native", "serde"] }
+ursa = { version = "=0.3.7", default-features = false, features = ["cl_native", "serde"] }
 zeroize = { version = "1.3", optional = true, features = ["zeroize_derive"] }
 
 # We add the openssl dependency here because ursa does not expose a vendored openssl feature


### PR DESCRIPTION
`ursa` version 0.3.6 still has dependencies on the long deprecated `failure` crate which is no longer maintained and contains well known security issues (CVE-2019-25010 and CVE-2020-25575).

fix #123 