### PR TITLE
Add linux arm64 as release target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,10 @@ jobs:
             arch: linux-x86_64
             target: x86_64-unknown-linux-gnu
             lib: libanoncreds.so
+          - os: ubuntu-latest
+            arch: linux-aarch64
+            target: aarch64-unknown-linux-gnu
+            lib: libanoncreds.so
           - os: macos-latest
             arch: darwin-x86_64
             lib: libanoncreds.dylib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,6 +109,14 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Install gcc for linux-aarch64
+        if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install gcc-aarch64-linux-gnu
+          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
+          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
+
       - name: Cache cargo resources
         uses: Swatinem/rust-cache@v2
 
@@ -118,7 +126,7 @@ jobs:
           OPENSSL_STATIC: 1
         run: cargo build --release --package anoncreds --target ${{matrix.target}} --features vendored
 
-      - name: Build library for macOS and Linux
+      - name: Build library for ${{ matrix.os }}
         if: "runner.os != 'Windows'"
         run: cargo build --release --package anoncreds --target ${{matrix.target}} --features vendored
 


### PR DESCRIPTION
Add linux arm64 distribution as target and a step for preparing the build environment for the aarch64-tooling.