### PR TITLE
refactor(js)!: use JSON objects in API instead of strings and instances

### DIFF
--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -84,12 +84,16 @@ export class NodeJSAnoncreds implements Anoncreds {
     tag: string
     signatureType: string
     supportRevocation: boolean
-  }): { credentialDefinition: ObjectHandle; credentialDefinitionPrivate: ObjectHandle; keyProof: ObjectHandle } {
+  }): {
+    credentialDefinition: ObjectHandle
+    credentialDefinitionPrivate: ObjectHandle
+    keyCorrectnessProof: ObjectHandle
+  } {
     const { schemaId, issuerId, schema, tag, signatureType, supportRevocation } = serializeArguments(options)
 
     const credentialDefinitionPtr = allocatePointer()
     const credentialDefinitionPrivatePtr = allocatePointer()
-    const keyProofPtr = allocatePointer()
+    const keyCorrectnessProofPtr = allocatePointer()
 
     nativeAnoncreds.anoncreds_create_credential_definition(
       schemaId,
@@ -100,14 +104,14 @@ export class NodeJSAnoncreds implements Anoncreds {
       supportRevocation,
       credentialDefinitionPtr,
       credentialDefinitionPrivatePtr,
-      keyProofPtr
+      keyCorrectnessProofPtr
     )
     handleError()
 
     return {
       credentialDefinition: new ObjectHandle(credentialDefinitionPtr.deref() as number),
       credentialDefinitionPrivate: new ObjectHandle(credentialDefinitionPrivatePtr.deref() as number),
-      keyProof: new ObjectHandle(keyProofPtr.deref() as number),
+      keyCorrectnessProof: new ObjectHandle(keyCorrectnessProofPtr.deref() as number),
     }
   }
 
@@ -223,12 +227,12 @@ export class NodeJSAnoncreds implements Anoncreds {
   public createCredentialOffer(options: {
     schemaId: string
     credentialDefinitionId: string
-    keyProof: ObjectHandle
+    keyCorrectnessProof: ObjectHandle
   }): ObjectHandle {
-    const { schemaId, credentialDefinitionId, keyProof } = serializeArguments(options)
+    const { schemaId, credentialDefinitionId, keyCorrectnessProof } = serializeArguments(options)
 
     const ret = allocatePointer()
-    nativeAnoncreds.anoncreds_create_credential_offer(schemaId, credentialDefinitionId, keyProof, ret)
+    nativeAnoncreds.anoncreds_create_credential_offer(schemaId, credentialDefinitionId, keyCorrectnessProof, ret)
     handleError()
 
     return new ObjectHandle(ret.deref() as number)

--- a/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
@@ -175,7 +175,7 @@ describe('API', () => {
 
     expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
 
-    const verify = Presentation.fromJson(presentation.toJson()).verify({
+    const verify = presentation.verify({
       presentationRequest,
       schemas: { ['mock:uri']: schema },
       credentialDefinitions: { ['mock:uri']: credentialDefinition },
@@ -319,7 +319,7 @@ describe('API', () => {
 
     expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
 
-    const verify = Presentation.fromJson(presentation.toJson()).verify({
+    const verify = presentation.verify({
       presentationRequest,
       schemas: { ['mock:uri']: schema },
       credentialDefinitions: { ['mock:uri']: credentialDefinition },

--- a/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
@@ -368,6 +368,7 @@ test('create and verify presentation passing only JSON objects as parameters)', 
   const masterSecretId = 'master secret id'
 
   const { credentialRequestMetadata, credentialRequest } = CredentialRequest.create({
+    entropy: 'entropy',
     credentialDefinition: credentialDefinition.toJson(),
     masterSecret: masterSecret.toJson(),
     masterSecretId,

--- a/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
@@ -22,32 +22,30 @@ describe('API', () => {
   test('create and verify presentation', () => {
     const nonce = anoncreds.generateNonce()
 
-    const presentationRequest = PresentationRequest.load(
-      JSON.stringify({
-        nonce,
-        name: 'pres_req_1',
-        version: '0.1',
-        requested_attributes: {
-          attr1_referent: {
-            name: 'name',
-            issuer: 'mock:uri',
-          },
-          attr2_referent: {
-            name: 'sex',
-          },
-          attr3_referent: {
-            name: 'phone',
-          },
-          attr4_referent: {
-            names: ['name', 'height'],
-          },
+    const presentationRequest = PresentationRequest.fromJson({
+      nonce,
+      name: 'pres_req_1',
+      version: '0.1',
+      requested_attributes: {
+        attr1_referent: {
+          name: 'name',
+          issuer: 'mock:uri',
         },
-        requested_predicates: {
-          predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+        attr2_referent: {
+          name: 'sex',
         },
-        non_revoked: { from: 10, to: 200 },
-      })
-    )
+        attr3_referent: {
+          name: 'phone',
+        },
+        attr4_referent: {
+          names: ['name', 'height'],
+        },
+      },
+      requested_predicates: {
+        predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+      },
+      non_revoked: { from: 10, to: 200 },
+    })
 
     const schema = Schema.create({
       name: 'schema-1',
@@ -176,7 +174,7 @@ describe('API', () => {
 
     expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
 
-    const verify = Presentation.load(presentation.toJson()).verify({
+    const verify = Presentation.fromJson(presentation.toJson()).verify({
       presentationRequest,
       schemas: { ['mock:uri']: schema },
       credentialDefinitions: { ['mock:uri']: credentialDefinition },
@@ -235,7 +233,7 @@ describe('API', () => {
     })
 
     const credJson = credential.toJson()
-    expect(JSON.parse(credJson)).toEqual(
+    expect(credJson).toEqual(
       expect.objectContaining({
         cred_def_id: 'mock:uri',
         schema_id: 'mock:uri',
@@ -243,42 +241,40 @@ describe('API', () => {
     )
 
     const credReceivedJson = credential.toJson()
-    expect(JSON.parse(credReceivedJson)).toEqual(
+    expect(credReceivedJson).toEqual(
       expect.objectContaining({
         cred_def_id: 'mock:uri',
         schema_id: 'mock:uri',
       })
     )
-    expect(JSON.parse(credReceivedJson)).toHaveProperty('signature')
-    expect(JSON.parse(credReceivedJson)).toHaveProperty('witness')
+    expect(credReceivedJson).toHaveProperty('signature')
+    expect(credReceivedJson).toHaveProperty('witness')
 
     const nonce = anoncreds.generateNonce()
 
-    const presentationRequest = PresentationRequest.load(
-      JSON.stringify({
-        nonce,
-        name: 'pres_req_1',
-        version: '0.1',
-        requested_attributes: {
-          attr1_referent: {
-            name: 'name',
-            issuer: 'mock:uri',
-          },
-          attr2_referent: {
-            name: 'sex',
-          },
-          attr3_referent: {
-            name: 'phone',
-          },
-          attr4_referent: {
-            names: ['name', 'height'],
-          },
+    const presentationRequest = PresentationRequest.fromJson({
+      nonce,
+      name: 'pres_req_1',
+      version: '0.1',
+      requested_attributes: {
+        attr1_referent: {
+          name: 'name',
+          issuer: 'mock:uri',
         },
-        requested_predicates: {
-          predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+        attr2_referent: {
+          name: 'sex',
         },
-      })
-    )
+        attr3_referent: {
+          name: 'phone',
+        },
+        attr4_referent: {
+          names: ['name', 'height'],
+        },
+      },
+      requested_predicates: {
+        predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+      },
+    })
 
     const presentation = Presentation.create({
       presentationRequest,
@@ -321,7 +317,7 @@ describe('API', () => {
 
     expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
 
-    const verify = Presentation.load(presentation.toJson()).verify({
+    const verify = Presentation.fromJson(presentation.toJson()).verify({
       presentationRequest,
       schemas: { ['mock:uri']: schema },
       credentialDefinitions: { ['mock:uri']: credentialDefinition },
@@ -329,4 +325,157 @@ describe('API', () => {
 
     expect(verify).toBeTruthy()
   })
+})
+
+test('create and verify presentation passing only JSON objects as parameters)', () => {
+  // a schema can be created from JSON
+  const schema = Schema.fromJson({
+    name: 'schema-1',
+    issuerId: 'mock:uri',
+    version: '1',
+    attrNames: ['name', 'age', 'sex', 'height'],
+  })
+  expect(schema.toJson()).toEqual({
+    name: 'schema-1',
+    issuerId: 'mock:uri',
+    version: '1',
+    attrNames: expect.arrayContaining(['name', 'age', 'sex', 'height']),
+  })
+
+  const { credentialDefinition, keyCorrectnessProof, credentialDefinitionPrivate } = CredentialDefinition.create({
+    schemaId: 'mock:uri',
+    issuerId: 'mock:uri',
+    schema: {
+      name: 'schema-1',
+      issuerId: 'mock:uri',
+      version: '1',
+      attrNames: ['name', 'age', 'sex', 'height'],
+    },
+    signatureType: 'CL',
+    supportRevocation: false,
+    tag: 'TAG',
+  })
+
+  const credentialOffer = CredentialOffer.create({
+    schemaId: 'mock:uri',
+    credentialDefinitionId: 'mock:uri',
+    keyCorrectnessProof: keyCorrectnessProof.toJson(),
+  })
+
+  const masterSecret = MasterSecret.create()
+  const masterSecretId = 'master secret id'
+
+  const { credentialRequestMetadata, credentialRequest } = CredentialRequest.create({
+    credentialDefinition: credentialDefinition.toJson(),
+    masterSecret: masterSecret.toJson(),
+    masterSecretId,
+    credentialOffer: credentialOffer.toJson(),
+  })
+
+  const credential = Credential.create({
+    credentialDefinition: credentialDefinition.toJson(),
+    credentialDefinitionPrivate: credentialDefinitionPrivate.toJson(),
+    credentialOffer: credentialOffer.toJson(),
+    credentialRequest: credentialRequest.toJson(),
+    attributeRawValues: { name: 'Alex', height: '175', age: '28', sex: 'male' },
+  })
+
+  const credReceived = credential.process({
+    credentialDefinition: credentialDefinition.toJson(),
+    credentialRequestMetadata: credentialRequestMetadata.toJson(),
+    masterSecret: masterSecret.toJson(),
+  })
+
+  const credJson = credential.toJson()
+  expect(credJson).toEqual(
+    expect.objectContaining({
+      cred_def_id: 'mock:uri',
+      schema_id: 'mock:uri',
+    })
+  )
+
+  const credReceivedJson = credential.toJson()
+  expect(credReceivedJson).toEqual(
+    expect.objectContaining({
+      cred_def_id: 'mock:uri',
+      schema_id: 'mock:uri',
+    })
+  )
+  expect(credReceivedJson).toHaveProperty('signature')
+  expect(credReceivedJson).toHaveProperty('witness')
+
+  const nonce = anoncreds.generateNonce()
+
+  const presentationRequest = {
+    nonce,
+    name: 'pres_req_1',
+    version: '0.1',
+    requested_attributes: {
+      attr1_referent: {
+        name: 'name',
+        issuer: 'mock:uri',
+      },
+      attr2_referent: {
+        name: 'sex',
+      },
+      attr3_referent: {
+        name: 'phone',
+      },
+      attr4_referent: {
+        names: ['name', 'height'],
+      },
+    },
+    requested_predicates: {
+      predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
+    },
+  }
+
+  const presentation = Presentation.create({
+    presentationRequest,
+    credentials: [
+      {
+        credential: credReceived.toJson(),
+      },
+    ],
+    credentialDefinitions: { 'mock:uri': credentialDefinition.toJson() },
+    credentialsProve: [
+      {
+        entryIndex: 0,
+        isPredicate: false,
+        referent: 'attr1_referent',
+        reveal: true,
+      },
+      {
+        entryIndex: 0,
+        isPredicate: false,
+        referent: 'attr2_referent',
+        reveal: false,
+      },
+      {
+        entryIndex: 0,
+        isPredicate: false,
+        referent: 'attr4_referent',
+        reveal: true,
+      },
+      {
+        entryIndex: 0,
+        isPredicate: true,
+        referent: 'predicate1_referent',
+        reveal: true,
+      },
+    ],
+    masterSecret: masterSecret.toJson(),
+    schemas: { 'mock:uri': schema.toJson() },
+    selfAttest: { attr3_referent: '8-800-300' },
+  })
+
+  expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
+
+  const verify = Presentation.fromJson(presentation.toJson()).verify({
+    presentationRequest,
+    schemas: { ['mock:uri']: schema.toJson() },
+    credentialDefinitions: { ['mock:uri']: credentialDefinition.toJson() },
+  })
+
+  expect(verify).toBeTruthy()
 })

--- a/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
@@ -43,14 +43,15 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const { keyProof, credentialDefinition, credentialDefinitionPrivate } = anoncreds.createCredentialDefinition({
-      schemaId: 'mock:uri',
-      issuerId: 'mock:uri',
-      schema: schemaObj,
-      signatureType: 'CL',
-      supportRevocation: true,
-      tag: 'TAG',
-    })
+    const { keyCorrectnessProof, credentialDefinition, credentialDefinitionPrivate } =
+      anoncreds.createCredentialDefinition({
+        schemaId: 'mock:uri',
+        issuerId: 'mock:uri',
+        schema: schemaObj,
+        signatureType: 'CL',
+        supportRevocation: true,
+        tag: 'TAG',
+      })
 
     const credDefJson = anoncreds.getJson({ objectHandle: credentialDefinition })
     expect(JSON.parse(credDefJson)).toEqual(
@@ -65,9 +66,9 @@ describe('bindings', () => {
     const credDefPvtJson = anoncreds.getJson({ objectHandle: credentialDefinitionPrivate })
     expect(JSON.parse(credDefPvtJson)).toHaveProperty('value')
 
-    const keyProofJson = anoncreds.getJson({ objectHandle: keyProof })
-    expect(JSON.parse(keyProofJson)).toHaveProperty('c')
-    expect(JSON.parse(keyProofJson)).toHaveProperty('xr_cap')
+    const keyCorrectnessProofJson = anoncreds.getJson({ objectHandle: keyCorrectnessProof })
+    expect(JSON.parse(keyCorrectnessProofJson)).toHaveProperty('c')
+    expect(JSON.parse(keyCorrectnessProofJson)).toHaveProperty('xr_cap')
   })
 
   test('encode credential attributes', () => {
@@ -144,7 +145,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const { keyProof } = anoncreds.createCredentialDefinition({
+    const { keyCorrectnessProof } = anoncreds.createCredentialDefinition({
       schemaId: 'mock:uri',
       schema: schemaObj,
       issuerId: 'mock:uri',
@@ -156,7 +157,7 @@ describe('bindings', () => {
     const credOfferObj = anoncreds.createCredentialOffer({
       schemaId: 'mock:uri',
       credentialDefinitionId: 'mock:uri',
-      keyProof,
+      keyCorrectnessProof,
     })
 
     const json = anoncreds.getJson({ objectHandle: credOfferObj })
@@ -178,7 +179,7 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const { credentialDefinition, keyProof } = anoncreds.createCredentialDefinition({
+    const { credentialDefinition, keyCorrectnessProof } = anoncreds.createCredentialDefinition({
       schemaId: 'mock:uri',
       issuerId: 'mock:uri',
       schema: schemaObj,
@@ -190,7 +191,7 @@ describe('bindings', () => {
     const credOfferObj = anoncreds.createCredentialOffer({
       schemaId: 'mock:uri',
       credentialDefinitionId: 'mock:uri',
-      keyProof,
+      keyCorrectnessProof,
     })
 
     const masterSecret = anoncreds.createMasterSecret()
@@ -230,14 +231,15 @@ describe('bindings', () => {
       attributeNames: ['attr-1'],
     })
 
-    const { credentialDefinition, keyProof, credentialDefinitionPrivate } = anoncreds.createCredentialDefinition({
-      schemaId: 'mock:uri',
-      issuerId: 'mock:uri',
-      schema: schemaObj,
-      signatureType: 'CL',
-      supportRevocation: true,
-      tag: 'TAG',
-    })
+    const { credentialDefinition, keyCorrectnessProof, credentialDefinitionPrivate } =
+      anoncreds.createCredentialDefinition({
+        schemaId: 'mock:uri',
+        issuerId: 'mock:uri',
+        schema: schemaObj,
+        signatureType: 'CL',
+        supportRevocation: true,
+        tag: 'TAG',
+      })
 
     const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } =
       anoncreds.createRevocationRegistryDefinition({
@@ -266,7 +268,7 @@ describe('bindings', () => {
     const credentialOffer = anoncreds.createCredentialOffer({
       schemaId: 'mock:uri',
       credentialDefinitionId: 'mock:uri',
-      keyProof,
+      keyCorrectnessProof,
     })
 
     const masterSecret = anoncreds.createMasterSecret()
@@ -363,14 +365,15 @@ describe('bindings', () => {
       attributeNames: ['name', 'age', 'sex', 'height'],
     })
 
-    const { credentialDefinition, keyProof, credentialDefinitionPrivate } = anoncreds.createCredentialDefinition({
-      schemaId: 'mock:uri',
-      issuerId: 'mock:uri',
-      schema: schemaObj,
-      signatureType: 'CL',
-      supportRevocation: true,
-      tag: 'TAG',
-    })
+    const { credentialDefinition, keyCorrectnessProof, credentialDefinitionPrivate } =
+      anoncreds.createCredentialDefinition({
+        schemaId: 'mock:uri',
+        issuerId: 'mock:uri',
+        schema: schemaObj,
+        signatureType: 'CL',
+        supportRevocation: true,
+        tag: 'TAG',
+      })
 
     const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate } =
       anoncreds.createRevocationRegistryDefinition({
@@ -399,7 +402,7 @@ describe('bindings', () => {
     const credentialOffer = anoncreds.createCredentialOffer({
       schemaId: 'mock:uri',
       credentialDefinitionId: 'mock:uri',
-      keyProof,
+      keyCorrectnessProof,
     })
 
     const masterSecret = anoncreds.createMasterSecret()
@@ -516,19 +519,20 @@ describe('bindings', () => {
       attributeNames: ['name', 'age', 'sex', 'height'],
     })
 
-    const { credentialDefinition, keyProof, credentialDefinitionPrivate } = anoncreds.createCredentialDefinition({
-      schemaId: 'mock:uri',
-      issuerId: 'mock:uri',
-      schema: schemaObj,
-      signatureType: 'CL',
-      supportRevocation: false,
-      tag: 'TAG',
-    })
+    const { credentialDefinition, keyCorrectnessProof, credentialDefinitionPrivate } =
+      anoncreds.createCredentialDefinition({
+        schemaId: 'mock:uri',
+        issuerId: 'mock:uri',
+        schema: schemaObj,
+        signatureType: 'CL',
+        supportRevocation: false,
+        tag: 'TAG',
+      })
 
     const credentialOffer = anoncreds.createCredentialOffer({
       schemaId: 'mock:uri',
       credentialDefinitionId: 'mock:uri',
-      keyProof,
+      keyCorrectnessProof,
     })
 
     const masterSecret = anoncreds.createMasterSecret()

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -103,19 +103,19 @@ jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialDefinitionP;
   ObjectHandle credentialDefinitionPrivateP;
-  ObjectHandle keyProofP;
+  ObjectHandle keyCorrectnessProofP;
 
   ErrorCode code = anoncreds_create_credential_definition(
       schemaId.c_str(), schema, tag.c_str(), issuerId.c_str(),
       signatureType.c_str(), supportRevocation, &credentialDefinitionP,
-      &credentialDefinitionPrivateP, &keyProofP);
+      &credentialDefinitionPrivateP, &keyCorrectnessProofP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
   object.setProperty(rt, "credentialDefinition", int(credentialDefinitionP));
   object.setProperty(rt, "credentialDefinitionPrivate",
                      int(credentialDefinitionPrivateP));
-  object.setProperty(rt, "keyProof", int(keyProofP));
+  object.setProperty(rt, "keyCorrectnessProof", int(keyCorrectnessProofP));
   return object;
 };
 
@@ -218,12 +218,12 @@ jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options) {
   auto schemaId = jsiToValue<std::string>(rt, options, "schemaId");
   auto credentialDefinitionId =
       jsiToValue<std::string>(rt, options, "credentialDefinitionId");
-  auto keyProof = jsiToValue<ObjectHandle>(rt, options, "keyProof");
+  auto keyCorrectnessProof = jsiToValue<ObjectHandle>(rt, options, "keyCorrectnessProof");
 
   ObjectHandle credOfferP;
 
   ErrorCode code = anoncreds_create_credential_offer(
-      schemaId.c_str(), credentialDefinitionId.c_str(), keyProof, &credOfferP);
+      schemaId.c_str(), credentialDefinitionId.c_str(), keyCorrectnessProof, &credOfferP);
   handleError(rt, code);
 
   return jsi::Value(int(credOfferP));

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -69,14 +69,18 @@ export class ReactNativeAnoncreds implements Anoncreds {
     issuerId: string
     signatureType: string
     supportRevocation: boolean
-  }): { credentialDefinition: ObjectHandle; credentialDefinitionPrivate: ObjectHandle; keyProof: ObjectHandle } {
-    const { keyProof, credentialDefinition, credentialDefinitionPrivate } =
+  }): {
+    credentialDefinition: ObjectHandle
+    credentialDefinitionPrivate: ObjectHandle
+    keyCorrectnessProof: ObjectHandle
+  } {
+    const { keyCorrectnessProof, credentialDefinition, credentialDefinitionPrivate } =
       anoncredsReactNative.createCredentialDefinition(serializeArguments(options))
 
     return {
       credentialDefinitionPrivate: new ObjectHandle(credentialDefinitionPrivate),
       credentialDefinition: new ObjectHandle(credentialDefinition),
-      keyProof: new ObjectHandle(keyProof),
+      keyCorrectnessProof: new ObjectHandle(keyCorrectnessProof),
     }
   }
 
@@ -113,7 +117,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
   public createCredentialOffer(options: {
     schemaId: string
     credentialDefinitionId: string
-    keyProof: ObjectHandle
+    keyCorrectnessProof: ObjectHandle
   }): ObjectHandle {
     const handle = anoncredsReactNative.createCredentialOffer(serializeArguments(options))
     return new ObjectHandle(handle)

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -33,7 +33,7 @@ export interface NativeBindings {
     tag: string
     signatureType: string
     supportRevocation: number
-  }): { credentialDefinition: _Handle; credentialDefinitionPrivate: _Handle; keyProof: _Handle }
+  }): { credentialDefinition: _Handle; credentialDefinitionPrivate: _Handle; keyCorrectnessProof: _Handle }
   createCredential(options: {
     credentialDefinition: number
     credentialDefinitionPrivate: number
@@ -51,7 +51,11 @@ export interface NativeBindings {
     credentialDefinition: number
     revocationRegistryDefinition?: number
   }): _Handle
-  createCredentialOffer(options: { schemaId: string; credentialDefinitionId: string; keyProof: number }): _Handle
+  createCredentialOffer(options: {
+    schemaId: string
+    credentialDefinitionId: string
+    keyCorrectnessProof: number
+  }): _Handle
   createCredentialRequest(options: {
     proverDid?: string
     credentialDefinition: number

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -51,7 +51,11 @@ export interface Anoncreds {
     issuerId: string
     signatureType: string
     supportRevocation: boolean
-  }): { credentialDefinition: ObjectHandle; credentialDefinitionPrivate: ObjectHandle; keyProof: ObjectHandle }
+  }): {
+    credentialDefinition: ObjectHandle
+    credentialDefinitionPrivate: ObjectHandle
+    keyCorrectnessProof: ObjectHandle
+  }
 
   createCredential(options: {
     credentialDefinition: ObjectHandle
@@ -78,7 +82,7 @@ export interface Anoncreds {
   createCredentialOffer(options: {
     schemaId: string
     credentialDefinitionId: string
-    keyProof: ObjectHandle
+    keyCorrectnessProof: ObjectHandle
   }): ObjectHandle
 
   createCredentialRequest(options: {

--- a/wrappers/javascript/anoncreds-shared/src/AnoncredsObject.ts
+++ b/wrappers/javascript/anoncreds-shared/src/AnoncredsObject.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from './types'
+
 import { ObjectHandle } from './ObjectHandle'
 import { anoncreds } from './register'
 
@@ -9,6 +11,6 @@ export class AnoncredsObject {
   }
 
   public toJson() {
-    return anoncreds.getJson({ objectHandle: this.handle })
+    return JSON.parse(anoncreds.getJson({ objectHandle: this.handle })) as JsonObject
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/Credential.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/Credential.ts
@@ -36,6 +36,8 @@ export type ProcessCredentialOptions = {
 
 export class Credential extends AnoncredsObject {
   public static create(options: CreateCredentialOptions) {
+    let credential
+    // Objects created within this method must be freed up
     const objectHandles: ObjectHandle[] = []
     try {
       const credentialDefinition =
@@ -65,7 +67,7 @@ export class Credential extends AnoncredsObject {
           ? pushToArray(RevocationStatusList.fromJson(options.revocationStatusList).handle, objectHandles)
           : undefined
 
-      const credential = anoncreds.createCredential({
+      credential = anoncreds.createCredential({
         credentialDefinition,
         credentialDefinitionPrivate,
         credentialOffer,
@@ -76,10 +78,10 @@ export class Credential extends AnoncredsObject {
         revocationConfiguration: options.revocationConfiguration?.native,
         revocationStatusList,
       })
-      return new Credential(credential.handle)
     } finally {
       objectHandles.forEach((handle) => handle.clear())
     }
+    return new Credential(credential.handle)
   }
 
   public static fromJson(json: JsonObject) {
@@ -87,6 +89,7 @@ export class Credential extends AnoncredsObject {
   }
 
   public process(options: ProcessCredentialOptions) {
+    let credential
     // Objects created within this method must be freed up
     const objectHandles: ObjectHandle[] = []
     try {
@@ -115,7 +118,7 @@ export class Credential extends AnoncredsObject {
             )
           : undefined
 
-      const credential = anoncreds.processCredential({
+      credential = anoncreds.processCredential({
         credential: this.handle,
         credentialDefinition,
         credentialRequestMetadata,
@@ -126,11 +129,10 @@ export class Credential extends AnoncredsObject {
       // We can discard previous handle and store the new one
       this.handle.clear()
       this.handle = credential
-
-      return this
     } finally {
       objectHandles.forEach((handle) => handle.clear())
     }
+    return this
   }
 
   public get schemaId() {

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialDefinition.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialDefinition.ts
@@ -20,28 +20,34 @@ export type CreateCredentialDefinitionOptions = {
 
 export class CredentialDefinition extends AnoncredsObject {
   public static create(options: CreateCredentialDefinitionOptions) {
+    let createReturnObj: {
+      credentialDefinition: ObjectHandle
+      credentialDefinitionPrivate: ObjectHandle
+      keyCorrectnessProof: ObjectHandle
+    }
+
+    // Objects created within this method must be freed up
     const objectHandles: ObjectHandle[] = []
     try {
       const schema =
         options.schema instanceof Schema
           ? options.schema.handle
           : pushToArray(Schema.fromJson(options.schema).handle, objectHandles)
-      const { credentialDefinition, credentialDefinitionPrivate, keyCorrectnessProof } =
-        anoncreds.createCredentialDefinition({
-          schemaId: options.schemaId,
-          schema,
-          signatureType: options.signatureType,
-          tag: options.tag,
-          issuerId: options.issuerId,
-          supportRevocation: options.supportRevocation ?? false,
-        })
-      return {
-        credentialDefinition: new CredentialDefinition(credentialDefinition.handle),
-        credentialDefinitionPrivate: new CredentialDefinitionPrivate(credentialDefinitionPrivate.handle),
-        keyCorrectnessProof: new KeyCorrectnessProof(keyCorrectnessProof.handle),
-      }
+      createReturnObj = anoncreds.createCredentialDefinition({
+        schemaId: options.schemaId,
+        schema,
+        signatureType: options.signatureType,
+        tag: options.tag,
+        issuerId: options.issuerId,
+        supportRevocation: options.supportRevocation ?? false,
+      })
     } finally {
       objectHandles.forEach((handle) => handle.clear())
+    }
+    return {
+      credentialDefinition: new CredentialDefinition(createReturnObj.credentialDefinition.handle),
+      credentialDefinitionPrivate: new CredentialDefinitionPrivate(createReturnObj.credentialDefinitionPrivate.handle),
+      keyCorrectnessProof: new KeyCorrectnessProof(createReturnObj.keyCorrectnessProof.handle),
     }
   }
 

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialDefinitionPrivate.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialDefinitionPrivate.ts
@@ -1,8 +1,12 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export class CredentialDefinitionPrivate extends AnoncredsObject {
-  public static load(json: string) {
-    return new CredentialDefinitionPrivate(anoncreds.credentialDefinitionPrivateFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new CredentialDefinitionPrivate(
+      anoncreds.credentialDefinitionPrivateFromJson({ json: JSON.stringify(json) }).handle
+    )
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialOffer.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialOffer.ts
@@ -15,6 +15,8 @@ export type CreateCredentialOfferOptions = {
 
 export class CredentialOffer extends AnoncredsObject {
   public static create(options: CreateCredentialOfferOptions) {
+    let credentialOfferHandle
+    // Objects created within this method must be freed up
     const objectHandles: ObjectHandle[] = []
     try {
       const keyCorrectnessProof =
@@ -22,16 +24,15 @@ export class CredentialOffer extends AnoncredsObject {
           ? options.keyCorrectnessProof.handle
           : pushToArray(KeyCorrectnessProof.fromJson(options.keyCorrectnessProof).handle, objectHandles)
 
-      return new CredentialOffer(
-        anoncreds.createCredentialOffer({
-          schemaId: options.schemaId,
-          credentialDefinitionId: options.credentialDefinitionId,
-          keyCorrectnessProof,
-        }).handle
-      )
+      credentialOfferHandle = anoncreds.createCredentialOffer({
+        schemaId: options.schemaId,
+        credentialDefinitionId: options.credentialDefinitionId,
+        keyCorrectnessProof,
+      }).handle
     } finally {
       objectHandles.forEach((handle) => handle.clear())
     }
+    return new CredentialOffer(credentialOfferHandle)
   }
 
   public static fromJson(json: JsonObject) {

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialOffer.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialOffer.ts
@@ -1,25 +1,40 @@
-import type { KeyCorrectnessProof } from './KeyCorrectnessProof'
+import type { ObjectHandle } from '../ObjectHandle'
+import type { JsonObject } from '../types'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
+import { KeyCorrectnessProof } from './KeyCorrectnessProof'
+import { pushToArray } from './utils'
+
 export type CreateCredentialOfferOptions = {
   schemaId: string
   credentialDefinitionId: string
-  keyCorrectnessProof: KeyCorrectnessProof
+  keyCorrectnessProof: KeyCorrectnessProof | JsonObject
 }
+
 export class CredentialOffer extends AnoncredsObject {
   public static create(options: CreateCredentialOfferOptions) {
-    return new CredentialOffer(
-      anoncreds.createCredentialOffer({
-        schemaId: options.schemaId,
-        credentialDefinitionId: options.credentialDefinitionId,
-        keyProof: options.keyCorrectnessProof.handle,
-      }).handle
-    )
+    const objectHandles: ObjectHandle[] = []
+    try {
+      const keyCorrectnessProof =
+        options.keyCorrectnessProof instanceof KeyCorrectnessProof
+          ? options.keyCorrectnessProof.handle
+          : pushToArray(KeyCorrectnessProof.fromJson(options.keyCorrectnessProof).handle, objectHandles)
+
+      return new CredentialOffer(
+        anoncreds.createCredentialOffer({
+          schemaId: options.schemaId,
+          credentialDefinitionId: options.credentialDefinitionId,
+          keyCorrectnessProof,
+        }).handle
+      )
+    } finally {
+      objectHandles.forEach((handle) => handle.clear())
+    }
   }
 
-  public static load(json: string) {
-    return new CredentialOffer(anoncreds.credentialOfferFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new CredentialOffer(anoncreds.credentialOfferFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRequest.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRequest.ts
@@ -20,6 +20,11 @@ export type CreateCredentialRequestOptions = {
 
 export class CredentialRequest extends AnoncredsObject {
   public static create(options: CreateCredentialRequestOptions) {
+    let createReturnObj: {
+      credentialRequest: ObjectHandle
+      credentialRequestMetadata: ObjectHandle
+    }
+    // Objects created within this method must be freed up
     const objectHandles: ObjectHandle[] = []
     try {
       const credentialDefinition =
@@ -37,20 +42,19 @@ export class CredentialRequest extends AnoncredsObject {
           ? options.credentialOffer.handle
           : pushToArray(CredentialOffer.fromJson(options.credentialOffer).handle, objectHandles)
 
-      const { credentialRequest, credentialRequestMetadata } = anoncreds.createCredentialRequest({
+      createReturnObj = anoncreds.createCredentialRequest({
         proverDid: options.proverDid,
         credentialDefinition,
         masterSecret,
         masterSecretId: options.masterSecretId,
         credentialOffer,
       })
-
-      return {
-        credentialRequest: new CredentialRequest(credentialRequest.handle),
-        credentialRequestMetadata: new CredentialRequestMetadata(credentialRequestMetadata.handle),
-      }
     } finally {
       objectHandles.forEach((handle) => handle.clear())
+    }
+    return {
+      credentialRequest: new CredentialRequest(createReturnObj.credentialRequest.handle),
+      credentialRequestMetadata: new CredentialRequestMetadata(createReturnObj.credentialRequestMetadata.handle),
     }
   }
 

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRequest.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRequest.ts
@@ -1,37 +1,60 @@
-import type { CredentialDefinition } from './CredentialDefinition'
-import type { CredentialOffer } from './CredentialOffer'
-import type { MasterSecret } from './MasterSecret'
+import type { ObjectHandle } from '../ObjectHandle'
+import type { JsonObject } from '../types'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
+import { CredentialDefinition } from './CredentialDefinition'
+import { CredentialOffer } from './CredentialOffer'
 import { CredentialRequestMetadata } from './CredentialRequestMetadata'
+import { MasterSecret } from './MasterSecret'
+import { pushToArray } from './utils'
 
 export type CreateCredentialRequestOptions = {
   proverDid?: string
-  credentialDefinition: CredentialDefinition
-  masterSecret: MasterSecret
+  credentialDefinition: CredentialDefinition | JsonObject
+  masterSecret: MasterSecret | JsonObject
   masterSecretId: string
-  credentialOffer: CredentialOffer
+  credentialOffer: CredentialOffer | JsonObject
 }
 
 export class CredentialRequest extends AnoncredsObject {
   public static create(options: CreateCredentialRequestOptions) {
-    const { credentialRequest, credentialRequestMetadata } = anoncreds.createCredentialRequest({
-      proverDid: options.proverDid,
-      credentialDefinition: options.credentialDefinition.handle,
-      masterSecret: options.masterSecret.handle,
-      masterSecretId: options.masterSecretId,
-      credentialOffer: options.credentialOffer.handle,
-    })
+    const objectHandles: ObjectHandle[] = []
+    try {
+      const credentialDefinition =
+        options.credentialDefinition instanceof CredentialDefinition
+          ? options.credentialDefinition.handle
+          : pushToArray(CredentialDefinition.fromJson(options.credentialDefinition).handle, objectHandles)
 
-    return {
-      credentialRequest: new CredentialRequest(credentialRequest.handle),
-      credentialRequestMetadata: new CredentialRequestMetadata(credentialRequestMetadata.handle),
+      const masterSecret =
+        options.masterSecret instanceof MasterSecret
+          ? options.masterSecret.handle
+          : pushToArray(MasterSecret.fromJson(options.masterSecret).handle, objectHandles)
+
+      const credentialOffer =
+        options.credentialOffer instanceof CredentialOffer
+          ? options.credentialOffer.handle
+          : pushToArray(CredentialOffer.fromJson(options.credentialOffer).handle, objectHandles)
+
+      const { credentialRequest, credentialRequestMetadata } = anoncreds.createCredentialRequest({
+        proverDid: options.proverDid,
+        credentialDefinition,
+        masterSecret,
+        masterSecretId: options.masterSecretId,
+        credentialOffer,
+      })
+
+      return {
+        credentialRequest: new CredentialRequest(credentialRequest.handle),
+        credentialRequestMetadata: new CredentialRequestMetadata(credentialRequestMetadata.handle),
+      }
+    } finally {
+      objectHandles.forEach((handle) => handle.clear())
     }
   }
 
-  public static load(json: string) {
-    return new CredentialRequest(anoncreds.credentialRequestFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new CredentialRequest(anoncreds.credentialRequestFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRequestMetadata.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRequestMetadata.ts
@@ -1,8 +1,12 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export class CredentialRequestMetadata extends AnoncredsObject {
-  public static load(json: string) {
-    return new CredentialRequestMetadata(anoncreds.credentialRequestMetadataFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new CredentialRequestMetadata(
+      anoncreds.credentialRequestMetadataFromJson({ json: JSON.stringify(json) }).handle
+    )
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationConfig.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationConfig.ts
@@ -22,6 +22,11 @@ export class CredentialRevocationConfig {
     this.tailsPath = options.tailsPath
   }
 
+  public clear() {
+    this.registryDefinition.handle.clear()
+    this.registryDefinitionPrivate.handle.clear()
+  }
+
   public get native(): NativeCredentialRevocationConfig {
     return {
       revocationRegistryDefinition: this.registryDefinition.handle,

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
@@ -1,9 +1,13 @@
-import type { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
+import type { ObjectHandle } from '../ObjectHandle'
+import type { JsonObject } from '../types'
 import type { RevocationRegistryDelta } from './RevocationRegistryDelta'
-import type { RevocationStatusList } from './RevocationStatusList'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
+
+import { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
+import { RevocationStatusList } from './RevocationStatusList'
+import { pushToArray } from './utils'
 
 export type CreateRevocationStateOptions = {
   revocationRegistryDefinition: RevocationRegistryDefinition
@@ -21,20 +25,38 @@ export type UpdateRevocationStateOptions = Required<
 
 export class CredentialRevocationState extends AnoncredsObject {
   public static create(options: CreateRevocationStateOptions) {
-    return new CredentialRevocationState(
-      anoncreds.createOrUpdateRevocationState({
-        revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
-        revocationStatusList: options.revocationStatusList.handle,
-        revocationRegistryIndex: options.revocationRegistryIndex,
-        tailsPath: options.tailsPath,
-        oldRevocationStatusList: undefined,
-        previousRevocationState: undefined,
-      }).handle
-    )
+    const objectHandles: ObjectHandle[] = []
+    try {
+      const revocationRegistryDefinition =
+        options.revocationRegistryDefinition instanceof RevocationRegistryDefinition
+          ? options.revocationRegistryDefinition.handle
+          : pushToArray(
+              RevocationRegistryDefinition.fromJson(options.revocationRegistryDefinition).handle,
+              objectHandles
+            )
+
+      const revocationStatusList =
+        options.revocationStatusList instanceof RevocationStatusList
+          ? options.revocationStatusList.handle
+          : pushToArray(RevocationStatusList.fromJson(options.revocationStatusList).handle, objectHandles)
+
+      return new CredentialRevocationState(
+        anoncreds.createOrUpdateRevocationState({
+          revocationRegistryDefinition,
+          revocationStatusList,
+          revocationRegistryIndex: options.revocationRegistryIndex,
+          tailsPath: options.tailsPath,
+          oldRevocationStatusList: undefined,
+          previousRevocationState: undefined,
+        }).handle
+      )
+    } finally {
+      objectHandles.forEach((handle) => handle.clear())
+    }
   }
 
-  public static load(json: string) {
-    return new CredentialRevocationState(anoncreds.revocationStateFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new CredentialRevocationState(anoncreds.revocationStateFromJson({ json: JSON.stringify(json) }).handle)
   }
 
   public update(options: UpdateRevocationStateOptions) {

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
@@ -25,6 +25,8 @@ export type UpdateRevocationStateOptions = Required<
 
 export class CredentialRevocationState extends AnoncredsObject {
   public static create(options: CreateRevocationStateOptions) {
+    let credentialRevocationStateHandle
+    // Objects created within this method must be freed up
     const objectHandles: ObjectHandle[] = []
     try {
       const revocationRegistryDefinition =
@@ -40,19 +42,18 @@ export class CredentialRevocationState extends AnoncredsObject {
           ? options.revocationStatusList.handle
           : pushToArray(RevocationStatusList.fromJson(options.revocationStatusList).handle, objectHandles)
 
-      return new CredentialRevocationState(
-        anoncreds.createOrUpdateRevocationState({
-          revocationRegistryDefinition,
-          revocationStatusList,
-          revocationRegistryIndex: options.revocationRegistryIndex,
-          tailsPath: options.tailsPath,
-          oldRevocationStatusList: undefined,
-          previousRevocationState: undefined,
-        }).handle
-      )
+      credentialRevocationStateHandle = anoncreds.createOrUpdateRevocationState({
+        revocationRegistryDefinition,
+        revocationStatusList,
+        revocationRegistryIndex: options.revocationRegistryIndex,
+        tailsPath: options.tailsPath,
+        oldRevocationStatusList: undefined,
+        previousRevocationState: undefined,
+      }).handle
     } finally {
       objectHandles.forEach((handle) => handle.clear())
     }
+    return new CredentialRevocationState(credentialRevocationStateHandle)
   }
 
   public static fromJson(json: JsonObject) {

--- a/wrappers/javascript/anoncreds-shared/src/api/KeyCorrectnessProof.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/KeyCorrectnessProof.ts
@@ -1,8 +1,10 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export class KeyCorrectnessProof extends AnoncredsObject {
-  public static load(json: string) {
-    return new KeyCorrectnessProof(anoncreds.keyCorrectnessProofFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new KeyCorrectnessProof(anoncreds.keyCorrectnessProofFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/MasterSecret.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/MasterSecret.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
@@ -6,7 +8,7 @@ export class MasterSecret extends AnoncredsObject {
     return new MasterSecret(anoncreds.createMasterSecret().handle)
   }
 
-  public static load(json: string) {
-    return new MasterSecret(anoncreds.masterSecretFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new MasterSecret(anoncreds.masterSecretFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/PresentationRequest.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/PresentationRequest.ts
@@ -1,8 +1,10 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export class PresentationRequest extends AnoncredsObject {
-  public static load(json: string) {
-    return new PresentationRequest(anoncreds.presentationRequestFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new PresentationRequest(anoncreds.presentationRequestFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistry.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistry.ts
@@ -1,3 +1,4 @@
+import type { JsonObject } from '../types'
 import type { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
 
 import { AnoncredsObject } from '../AnoncredsObject'
@@ -17,7 +18,7 @@ export type UpdateRevocationRegistryOptions = {
 }
 
 export class RevocationRegistry extends AnoncredsObject {
-  public static load(json: string) {
-    return new RevocationRegistry(anoncreds.revocationRegistryFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new RevocationRegistry(anoncreds.revocationRegistryFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
@@ -20,6 +20,12 @@ export type CreateRevocationRegistryDefinitionOptions = {
 
 export class RevocationRegistryDefinition extends AnoncredsObject {
   public static create(options: CreateRevocationRegistryDefinitionOptions) {
+    let createReturnObj: {
+      revocationRegistryDefinition: ObjectHandle
+      revocationRegistryDefinitionPrivate: ObjectHandle
+    }
+    // Objects created within this method must be freed up
+
     const objectHandles: ObjectHandle[] = []
     try {
       const credentialDefinition =
@@ -27,20 +33,20 @@ export class RevocationRegistryDefinition extends AnoncredsObject {
           ? options.credentialDefinition.handle
           : pushToArray(CredentialDefinition.fromJson(options.credentialDefinition).handle, objectHandles)
 
-      const {
-        revocationRegistryDefinition: registryDefinition,
-        revocationRegistryDefinitionPrivate: registryDefinitionPrivate,
-      } = anoncreds.createRevocationRegistryDefinition({
+      createReturnObj = anoncreds.createRevocationRegistryDefinition({
         ...options,
         credentialDefinition,
       })
-
-      return {
-        revocationRegistryDefinition: new RevocationRegistryDefinition(registryDefinition.handle),
-        revocationRegistryDefinitionPrivate: new RevocationRegistryDefinitionPrivate(registryDefinitionPrivate.handle),
-      }
     } finally {
       objectHandles.forEach((handle) => handle.clear())
+    }
+    return {
+      revocationRegistryDefinition: new RevocationRegistryDefinition(
+        createReturnObj.revocationRegistryDefinition.handle
+      ),
+      revocationRegistryDefinitionPrivate: new RevocationRegistryDefinitionPrivate(
+        createReturnObj.revocationRegistryDefinitionPrivate.handle
+      ),
     }
   }
 

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinition.ts
@@ -1,12 +1,15 @@
-import type { CredentialDefinition } from './CredentialDefinition'
+import type { ObjectHandle } from '../ObjectHandle'
+import type { JsonObject } from '../types'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
+import { CredentialDefinition } from './CredentialDefinition'
 import { RevocationRegistryDefinitionPrivate } from './RevocationRegistryDefinitionPrivate'
+import { pushToArray } from './utils'
 
 export type CreateRevocationRegistryDefinitionOptions = {
-  credentialDefinition: CredentialDefinition
+  credentialDefinition: CredentialDefinition | JsonObject
   credentialDefinitionId: string
   tag: string
   issuerId: string
@@ -17,22 +20,34 @@ export type CreateRevocationRegistryDefinitionOptions = {
 
 export class RevocationRegistryDefinition extends AnoncredsObject {
   public static create(options: CreateRevocationRegistryDefinitionOptions) {
-    const {
-      revocationRegistryDefinition: registryDefinition,
-      revocationRegistryDefinitionPrivate: registryDefinitionPrivate,
-    } = anoncreds.createRevocationRegistryDefinition({
-      ...options,
-      credentialDefinition: options.credentialDefinition.handle,
-    })
+    const objectHandles: ObjectHandle[] = []
+    try {
+      const credentialDefinition =
+        options.credentialDefinition instanceof CredentialDefinition
+          ? options.credentialDefinition.handle
+          : pushToArray(CredentialDefinition.fromJson(options.credentialDefinition).handle, objectHandles)
 
-    return {
-      revocationRegistryDefinition: new RevocationRegistryDefinition(registryDefinition.handle),
-      revocationRegistryDefinitionPrivate: new RevocationRegistryDefinitionPrivate(registryDefinitionPrivate.handle),
+      const {
+        revocationRegistryDefinition: registryDefinition,
+        revocationRegistryDefinitionPrivate: registryDefinitionPrivate,
+      } = anoncreds.createRevocationRegistryDefinition({
+        ...options,
+        credentialDefinition,
+      })
+
+      return {
+        revocationRegistryDefinition: new RevocationRegistryDefinition(registryDefinition.handle),
+        revocationRegistryDefinitionPrivate: new RevocationRegistryDefinitionPrivate(registryDefinitionPrivate.handle),
+      }
+    } finally {
+      objectHandles.forEach((handle) => handle.clear())
     }
   }
 
-  public static load(json: string) {
-    return new RevocationRegistryDefinition(anoncreds.revocationRegistryDefinitionFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new RevocationRegistryDefinition(
+      anoncreds.revocationRegistryDefinitionFromJson({ json: JSON.stringify(json) }).handle
+    )
   }
 
   public getId() {

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinitionPrivate.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDefinitionPrivate.ts
@@ -1,10 +1,12 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export class RevocationRegistryDefinitionPrivate extends AnoncredsObject {
-  public static load(json: string) {
+  public static fromJson(json: JsonObject) {
     return new RevocationRegistryDefinitionPrivate(
-      anoncreds.revocationRegistryDefinitionPrivateFromJson({ json }).handle
+      anoncreds.revocationRegistryDefinitionPrivateFromJson({ json: JSON.stringify(json) }).handle
     )
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDelta.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationRegistryDelta.ts
@@ -1,8 +1,10 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
 export class RevocationRegistryDelta extends AnoncredsObject {
-  public static load(json: string) {
-    return new RevocationRegistryDelta(anoncreds.revocationRegistryDeltaFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new RevocationRegistryDelta(anoncreds.revocationRegistryDeltaFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
@@ -28,6 +28,7 @@ export type UpdateRevocationStatusListOptions = {
 
 export class RevocationStatusList extends AnoncredsObject {
   public static create(options: CreateRevocationStatusListOptions) {
+    let revocationStatusListHandle
     const objectHandles: ObjectHandle[] = []
     try {
       const revocationRegistryDefinition =
@@ -38,15 +39,16 @@ export class RevocationStatusList extends AnoncredsObject {
               objectHandles
             )
 
-      const revocationStatusList = anoncreds.createRevocationStatusList({
+      revocationStatusListHandle = anoncreds.createRevocationStatusList({
         ...options,
         revocationRegistryDefinition,
-      })
-      return new RevocationStatusList(revocationStatusList.handle)
+      }).handle
     } finally {
       objectHandles.forEach((handle) => handle.clear())
     }
+    return new RevocationStatusList(revocationStatusListHandle)
   }
+
   public static fromJson(json: JsonObject) {
     let revocationRegistryDefinition: RevocationRegistryDefinition | undefined = undefined
     try {

--- a/wrappers/javascript/anoncreds-shared/src/api/Schema.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/Schema.ts
@@ -1,3 +1,5 @@
+import type { JsonObject } from '../types'
+
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
 
@@ -13,7 +15,7 @@ export class Schema extends AnoncredsObject {
     return new Schema(anoncreds.createSchema(options).handle)
   }
 
-  public static load(json: string) {
-    return new Schema(anoncreds.schemaFromJson({ json }).handle)
+  public static fromJson(json: JsonObject) {
+    return new Schema(anoncreds.schemaFromJson({ json: JSON.stringify(json) }).handle)
   }
 }

--- a/wrappers/javascript/anoncreds-shared/src/api/utils.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/utils.ts
@@ -1,0 +1,1 @@
+export const pushToArray = <T>(obj: T, arr: T[]) => arr[arr.push(obj) - 1]

--- a/wrappers/javascript/anoncreds-shared/src/types.ts
+++ b/wrappers/javascript/anoncreds-shared/src/types.ts
@@ -16,3 +16,5 @@ export class ByteBuffer {
     return new ByteBuffer({ data, len: data.length })
   }
 }
+
+export type JsonObject = Record<string, unknown>


### PR DESCRIPTION
This is an attempt (without doing anything revolutionary) to make JS API a bit more simple to use, avoiding the so-many conversions from JSON to string  that we found during integration with AFJ. 

For most methods that are currently receiving `AnoncredsObject` instances, now we accept also passing JSON objects. This makes the caller to not care about object instantiation and clearing handles, which is done internally. Hopefully, in a normal flow the caller will need only to care about freeing a few objects (like Credentials).

I'm not sure if I'm using the `try-finally` method correctly (I'm particularly worried about the order of execution of finally if an exception is thrown) so any comments on this approach would be appreciated. I wanted to make this process of "checking object type and loading from JSON/add to handles to clear array" more elegant, but I think I'll need some more TypeScript lessons from @TimoGlastra and @blu3beri before attempting to do that 😛 .

Some tests were added to this repo, but I didn't check this as a patch of AFJ to see how is it going, something I'd like to do before merging. 

Summary of changes: 

- Refactor `load` in AnonCredsObjects to `fromJson`, loading from a JSON object rather than a string
- Refactor `toJson` in AnoncredsObject to return a JSON object rather than a string
- All constructors and methods in API AnoncredsObjects accept both AnonCredsObjects and JSON objects. This is the most tricky part: for every passed JSON object, an  ephemeral AnonCredsObject instance will be created and must be cleared before returning to the caller
- Add some missing fromJson (like the one from Credential)
- Rename keyProof -> keyCorrectnessProof to match the naming of other fields
