### PR TITLE
fix(js): missing getXXXFromJson methods and several typos

### DIFF
--- a/wrappers/javascript/anoncreds-react-native/cpp/HostObject.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/HostObject.cpp
@@ -52,6 +52,8 @@ FunctionMap AnoncredsTurboModuleHostObject::functionMapping(jsi::Runtime &rt) {
                                 &anoncreds::revocationRegistryDefinitionFromJson));
   fMap.insert(std::make_tuple("presentationFromJson",
                                 &anoncreds::presentationFromJson));
+  fMap.insert(std::make_tuple("presentationRequestFromJson",
+                                &anoncreds::presentationRequestFromJson));
   fMap.insert(std::make_tuple("credentialOfferFromJson",
                                 &anoncreds::credentialOfferFromJson));
   fMap.insert(std::make_tuple("schemaFromJson",

--- a/wrappers/javascript/anoncreds-react-native/cpp/HostObject.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/HostObject.cpp
@@ -46,6 +46,37 @@ FunctionMap AnoncredsTurboModuleHostObject::functionMapping(jsi::Runtime &rt) {
                               &anoncreds::updateRevocationStatusList));
   fMap.insert(std::make_tuple("objectFree", &anoncreds::objectFree));
 
+  fMap.insert(std::make_tuple("credentialDefinitionFromJson",
+                                &anoncreds::credentialDefinitionFromJson));
+  fMap.insert(std::make_tuple("revocationRegistryDefinitionFromJson",
+                                &anoncreds::revocationRegistryDefinitionFromJson));
+  fMap.insert(std::make_tuple("presentationFromJson",
+                                &anoncreds::presentationFromJson));
+  fMap.insert(std::make_tuple("credentialOfferFromJson",
+                                &anoncreds::credentialOfferFromJson));
+  fMap.insert(std::make_tuple("schemaFromJson",
+                                &anoncreds::schemaFromJson));
+  fMap.insert(std::make_tuple("masterSecretFromJson",
+                                &anoncreds::masterSecretFromJson));
+  fMap.insert(std::make_tuple("credentialRequestFromJson",
+                                &anoncreds::credentialRequestFromJson));
+  fMap.insert(std::make_tuple("credentialRequestMetadataFromJson",
+                                &anoncreds::credentialRequestMetadataFromJson));
+  fMap.insert(std::make_tuple("credentialFromJson",
+                                &anoncreds::credentialFromJson));
+  fMap.insert(std::make_tuple("revocationRegistryDefinitionPrivateFromJson",
+                                &anoncreds::revocationRegistryDefinitionPrivateFromJson));
+  fMap.insert(std::make_tuple("revocationRegistryDeltaFromJson",
+                                &anoncreds::revocationRegistryDeltaFromJson));
+  fMap.insert(std::make_tuple("revocationStateFromJson",
+                                &anoncreds::revocationStateFromJson));
+  fMap.insert(std::make_tuple("credentialDefinitionFromJson",
+                                &anoncreds::credentialDefinitionFromJson));
+  fMap.insert(std::make_tuple("credentialDefinitionPrivateFromJson",
+                                &anoncreds::credentialDefinitionPrivateFromJson));
+  fMap.insert(std::make_tuple("keyCorrectnessProofFromJson",
+                                &anoncreds::keyCorrectnessProofFromJson));
+
   return fMap;
 }
 

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -119,6 +119,293 @@ jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
   return object;
 };
 
+// ===== AnonCreds Objects from JSON =====
+
+jsi::Value revocationRegistryDefinitionFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle revocationRegistryDefinitionP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_revocation_registry_definition_from_json(b, &revocationRegistryDefinitionP);
+  handleError(rt, code);
+
+  return jsi::Value(int(revocationRegistryDefinitionP));
+};
+
+jsi::Value revocationRegistryFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle revocationRegistryP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_revocation_registry_from_json(b, &revocationRegistryP);
+  handleError(rt, code);
+
+  return jsi::Value(int(revocationRegistryP));
+};
+
+jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle presentationP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_presentation_from_json(b, &presentationP);
+  handleError(rt, code);
+
+  return jsi::Value(int(presentationP));
+};
+
+jsi::Value credentialOfferFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle credentialOfferP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_credential_offer_from_json(b, &credentialOfferP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialOfferP));
+};
+
+jsi::Value schemaFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle schemaP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_schema_from_json(b, &schemaP);
+  handleError(rt, code);
+
+  return jsi::Value(int(schemaP));
+};
+
+jsi::Value masterSecretFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle masterSecretP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_master_secret_from_json(b, &masterSecretP);
+  handleError(rt, code);
+
+  return jsi::Value(int(masterSecretP));
+};
+
+jsi::Value credentialRequestFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle credentialRequestP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_credential_request_from_json(b, &credentialRequestP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialRequestP));
+};
+
+jsi::Value credentialRequestMetadataFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle credentialRequestMetadataP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_credential_request_metadata_from_json(b, &credentialRequestMetadataP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialRequestMetadataP));
+};
+
+jsi::Value credentialFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle credentialP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_credential_from_json(b, &credentialP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialP));
+};
+
+jsi::Value revocationRegistryDefinitionPrivateFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle revocationRegistryDefinitionPrivateP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_revocation_registry_definition_private_from_json(b, &revocationRegistryDefinitionPrivateP);
+  handleError(rt, code);
+
+  return jsi::Value(int(revocationRegistryDefinitionPrivateP));
+};
+
+jsi::Value revocationStateFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle revocationStateP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_revocation_state_from_json(b, &revocationStateP);
+  handleError(rt, code);
+
+  return jsi::Value(int(revocationStateP));
+};
+
+jsi::Value revocationRegistryDeltaFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle revocationRegistryDeltaP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_revocation_registry_delta_from_json(b, &revocationRegistryDeltaP);
+  handleError(rt, code);
+
+  return jsi::Value(int(revocationRegistryDeltaP));
+};
+
+jsi::Value credentialDefinitionFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle credentialDefinitionP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_credential_definition_from_json(b, &credentialDefinitionP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialDefinitionP));
+};
+
+jsi::Value credentialDefinitionPrivateFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle credentialDefinitionPrivateP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_credential_definition_private_from_json(b, &credentialDefinitionPrivateP);
+  handleError(rt, code);
+
+  return jsi::Value(int(credentialDefinitionPrivateP));
+};
+
+jsi::Value keyCorrectnessProofFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle keyCorrectnessProofP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_key_correctness_proof_from_json(b, &keyCorrectnessProofP);
+  handleError(rt, code);
+
+  return jsi::Value(int(keyCorrectnessProofP));
+};
+
 // ===== PROOFS =====
 
 jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
@@ -132,7 +419,7 @@ jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
       jsiToValue<FfiStrList>(rt, options, "selfAttestedNames");
   auto selfAttestedValues =
       jsiToValue<FfiStrList>(rt, options, "selfAttestedValues");
-  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSercet");
+  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSecret");
   auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
   auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
   auto credentialDefinitions =
@@ -242,13 +529,13 @@ jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options) {
   ObjectHandle credReqMetaP;
 
   ErrorCode code = anoncreds_create_credential_request(
-      proverDid.c_str(), credentialDefinition, masterSecret,
+      proverDid.length() > 0 ? proverDid.c_str() : nullptr, credentialDefinition, masterSecret,
       masterSecretId.c_str(), credentialOffer, &credReqP, &credReqMetaP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
-  object.setProperty(rt, "credReq", int(credReqP));
-  object.setProperty(rt, "credReqMeta", int(credReqMetaP));
+  object.setProperty(rt, "credentialRequest", int(credReqP));
+  object.setProperty(rt, "credentialRequestMetadata", int(credReqMetaP));
   return object;
 };
 
@@ -282,11 +569,11 @@ jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
   auto credential = jsiToValue<ObjectHandle>(rt, options, "credential");
   auto credentialRequestMetadata =
       jsiToValue<ObjectHandle>(rt, options, "credentialRequestMetadata");
-  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSercet");
+  auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSecret");
   auto credentialDefinition =
       jsiToValue<ObjectHandle>(rt, options, "credentialDefinition");
   auto revocationRegistryDefinition =
-      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition");
+      jsiToValue<ObjectHandle>(rt, options, "revocationRegistryDefinition", true);
 
   ObjectHandle credentialP;
 

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -103,19 +103,19 @@ jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialDefinitionP;
   ObjectHandle credentialDefinitionPrivateP;
-  ObjectHandle keyProofP;
+  ObjectHandle keyCorrectnessProofP;
 
   ErrorCode code = anoncreds_create_credential_definition(
       schemaId.c_str(), schema, tag.c_str(), issuerId.c_str(),
       signatureType.c_str(), supportRevocation, &credentialDefinitionP,
-      &credentialDefinitionPrivateP, &keyProofP);
+      &credentialDefinitionPrivateP, &keyCorrectnessProofP);
   handleError(rt, code);
 
   jsi::Object object = jsi::Object(rt);
   object.setProperty(rt, "credentialDefinition", int(credentialDefinitionP));
   object.setProperty(rt, "credentialDefinitionPrivate",
                      int(credentialDefinitionPrivateP));
-  object.setProperty(rt, "keyProof", int(keyProofP));
+  object.setProperty(rt, "keyCorrectnessProof", int(keyCorrectnessProofP));
   return object;
 };
 
@@ -524,12 +524,12 @@ jsi::Value createCredentialOffer(jsi::Runtime &rt, jsi::Object options) {
   auto schemaId = jsiToValue<std::string>(rt, options, "schemaId");
   auto credentialDefinitionId =
       jsiToValue<std::string>(rt, options, "credentialDefinitionId");
-  auto keyProof = jsiToValue<ObjectHandle>(rt, options, "keyProof");
+  auto keyCorrectnessProof = jsiToValue<ObjectHandle>(rt, options, "keyCorrectnessProof");
 
   ObjectHandle credOfferP;
 
   ErrorCode code = anoncreds_create_credential_offer(
-      schemaId.c_str(), credentialDefinitionId.c_str(), keyProof, &credOfferP);
+      schemaId.c_str(), credentialDefinitionId.c_str(), keyCorrectnessProof, &credOfferP);
   handleError(rt, code);
 
   return jsi::Value(int(credOfferP));
@@ -546,9 +546,9 @@ jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credReqP;
   ObjectHandle credReqMetaP;
-
+  
   ErrorCode code = anoncreds_create_credential_request(
-      proverDid.length() > 0 ? proverDid.c_str() : nullptr, credentialDefinition, masterSecret,
+      proverDid.length() ? proverDid.c_str() : nullptr, credentialDefinition, masterSecret,
       masterSecretId.c_str(), credentialOffer, &credReqP, &credReqMetaP);
   handleError(rt, code);
 
@@ -568,7 +568,7 @@ jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options) {
       anoncreds_credential_get_attribute(handle, name.c_str(), &resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP ? resultP : "{}");
+  return resultP != nullptr ? jsi::String::createFromAscii(rt, resultP) : jsi::Value::null();
 };
 
 jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
@@ -581,7 +581,7 @@ jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
       anoncreds_encode_credential_attributes(attributeRawValues, &resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP ? resultP : "{}");
+  return resultP != nullptr ? jsi::String::createFromAscii(rt, resultP) : jsi::Value::null();
 };
 
 jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
@@ -722,7 +722,7 @@ jsi::Value revocationRegistryDefinitionGetAttribute(jsi::Runtime &rt,
       handle, name.c_str(), &resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP ? resultP : "{}");
+  return resultP != nullptr ? jsi::String::createFromAscii(rt, resultP) : jsi::Value::null();
 };
 
 } // namespace anoncreds

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -178,6 +178,25 @@ jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options) {
   return jsi::Value(int(presentationP));
 };
 
+jsi::Value presentationRequestFromJson(jsi::Runtime &rt, jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle presentationRequestP;
+
+    ByteBuffer b;
+
+    std::vector<uint8_t> jsonVector(json.begin(), json.end());
+    uint8_t *p = &jsonVector[0];
+    
+    b.data = p;
+    b.len = json.length();
+    
+  ErrorCode code = anoncreds_presentation_request_from_json(b, &presentationRequestP);
+  handleError(rt, code);
+
+  return jsi::Value(int(presentationRequestP));
+};
+
 jsi::Value credentialOfferFromJson(jsi::Runtime &rt, jsi::Object options) {
   auto json = jsiToValue<std::string>(rt, options, "json");
 
@@ -354,7 +373,7 @@ jsi::Value credentialDefinitionFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialDefinitionP;
 
-    ByteBuffer b;
+      ByteBuffer b;
 
     std::vector<uint8_t> jsonVector(json.begin(), json.end());
     uint8_t *p = &jsonVector[0];
@@ -416,9 +435,9 @@ jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
   auto credentialsProve =
       jsiToValue<FfiList_FfiCredentialProve>(rt, options, "credentialsProve");
   auto selfAttestedNames =
-      jsiToValue<FfiStrList>(rt, options, "selfAttestedNames");
+      jsiToValue<FfiStrList>(rt, options, "selfAttestNames");
   auto selfAttestedValues =
-      jsiToValue<FfiStrList>(rt, options, "selfAttestedValues");
+      jsiToValue<FfiStrList>(rt, options, "selfAttestValues");
   auto masterSecret = jsiToValue<ObjectHandle>(rt, options, "masterSecret");
   auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
   auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
@@ -549,7 +568,7 @@ jsi::Value credentialGetAttribute(jsi::Runtime &rt, jsi::Object options) {
       anoncreds_credential_get_attribute(handle, name.c_str(), &resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, resultP ? resultP : "{}");
 };
 
 jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
@@ -562,7 +581,7 @@ jsi::Value encodeCredentialAttributes(jsi::Runtime &rt, jsi::Object options) {
       anoncreds_encode_credential_attributes(attributeRawValues, &resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, resultP ? resultP : "{}");
 };
 
 jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
@@ -703,7 +722,7 @@ jsi::Value revocationRegistryDefinitionGetAttribute(jsi::Runtime &rt,
       handle, name.c_str(), &resultP);
   handleError(rt, code);
 
-  return jsi::String::createFromAscii(rt, resultP);
+  return jsi::String::createFromAscii(rt, resultP ? resultP : "{}");
 };
 
 } // namespace anoncreds

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -121,19 +121,23 @@ jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options) {
 
 // ===== AnonCreds Objects from JSON =====
 
+ByteBuffer stringToByteBuffer(std::string str) {
+  ByteBuffer b;
+  std::vector<uint8_t> jsonVector(str.begin(), str.end());
+  uint8_t *p = &jsonVector[0];
+      
+  b.data = p;
+  b.len = str.length();
+  return b;
+}
+
 jsi::Value revocationRegistryDefinitionFromJson(jsi::Runtime &rt, jsi::Object options) {
   auto json = jsiToValue<std::string>(rt, options, "json");
 
   ObjectHandle revocationRegistryDefinitionP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_revocation_registry_definition_from_json(b, &revocationRegistryDefinitionP);
   handleError(rt, code);
 
@@ -145,14 +149,8 @@ jsi::Value revocationRegistryFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle revocationRegistryP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_revocation_registry_from_json(b, &revocationRegistryP);
   handleError(rt, code);
 
@@ -164,14 +162,8 @@ jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle presentationP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_presentation_from_json(b, &presentationP);
   handleError(rt, code);
 
@@ -183,13 +175,7 @@ jsi::Value presentationRequestFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle presentationRequestP;
 
-    ByteBuffer b;
-
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
+  ByteBuffer b = stringToByteBuffer(json);
     
   ErrorCode code = anoncreds_presentation_request_from_json(b, &presentationRequestP);
   handleError(rt, code);
@@ -202,14 +188,8 @@ jsi::Value credentialOfferFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialOfferP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_credential_offer_from_json(b, &credentialOfferP);
   handleError(rt, code);
 
@@ -221,14 +201,8 @@ jsi::Value schemaFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle schemaP;
 
-    ByteBuffer b;
-
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
+  ByteBuffer b = stringToByteBuffer(json);
+  
   ErrorCode code = anoncreds_schema_from_json(b, &schemaP);
   handleError(rt, code);
 
@@ -240,14 +214,8 @@ jsi::Value masterSecretFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle masterSecretP;
 
-    ByteBuffer b;
-
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
+  ByteBuffer b = stringToByteBuffer(json);
+  
   ErrorCode code = anoncreds_master_secret_from_json(b, &masterSecretP);
   handleError(rt, code);
 
@@ -259,14 +227,8 @@ jsi::Value credentialRequestFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialRequestP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_credential_request_from_json(b, &credentialRequestP);
   handleError(rt, code);
 
@@ -278,14 +240,8 @@ jsi::Value credentialRequestMetadataFromJson(jsi::Runtime &rt, jsi::Object optio
 
   ObjectHandle credentialRequestMetadataP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_credential_request_metadata_from_json(b, &credentialRequestMetadataP);
   handleError(rt, code);
 
@@ -297,14 +253,8 @@ jsi::Value credentialFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_credential_from_json(b, &credentialP);
   handleError(rt, code);
 
@@ -316,14 +266,8 @@ jsi::Value revocationRegistryDefinitionPrivateFromJson(jsi::Runtime &rt, jsi::Ob
 
   ObjectHandle revocationRegistryDefinitionPrivateP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_revocation_registry_definition_private_from_json(b, &revocationRegistryDefinitionPrivateP);
   handleError(rt, code);
 
@@ -335,14 +279,8 @@ jsi::Value revocationStateFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle revocationStateP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_revocation_state_from_json(b, &revocationStateP);
   handleError(rt, code);
 
@@ -354,14 +292,8 @@ jsi::Value revocationRegistryDeltaFromJson(jsi::Runtime &rt, jsi::Object options
 
   ObjectHandle revocationRegistryDeltaP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_revocation_registry_delta_from_json(b, &revocationRegistryDeltaP);
   handleError(rt, code);
 
@@ -373,14 +305,8 @@ jsi::Value credentialDefinitionFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle credentialDefinitionP;
 
-      ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_credential_definition_from_json(b, &credentialDefinitionP);
   handleError(rt, code);
 
@@ -392,14 +318,8 @@ jsi::Value credentialDefinitionPrivateFromJson(jsi::Runtime &rt, jsi::Object opt
 
   ObjectHandle credentialDefinitionPrivateP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_credential_definition_private_from_json(b, &credentialDefinitionPrivateP);
   handleError(rt, code);
 
@@ -411,14 +331,8 @@ jsi::Value keyCorrectnessProofFromJson(jsi::Runtime &rt, jsi::Object options) {
 
   ObjectHandle keyCorrectnessProofP;
 
-    ByteBuffer b;
+  ByteBuffer b = stringToByteBuffer(json);
 
-    std::vector<uint8_t> jsonVector(json.begin(), json.end());
-    uint8_t *p = &jsonVector[0];
-    
-    b.data = p;
-    b.len = json.length();
-    
   ErrorCode code = anoncreds_key_correctness_proof_from_json(b, &keyCorrectnessProofP);
   handleError(rt, code);
 
@@ -468,11 +382,11 @@ jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options) {
   auto credentialDefinitionIds =
       jsiToValue<FfiList_FfiStr>(rt, options, "credentialDefinitionIds");
   auto revocationRegistryDefinitions = jsiToValue<FfiList_ObjectHandle>(
-      rt, options, "revocationRegistryDefinitions");
+      rt, options, "revocationRegistryDefinitions", true);
   auto revocationRegistryDefinitionIds = jsiToValue<FfiList_FfiStr>(
-      rt, options, "revocationRegistryDefinitionIds");
+      rt, options, "revocationRegistryDefinitionIds", true);
   auto revocationStatusLists =
-      jsiToValue<FfiList_ObjectHandle>(rt, options, "revocationStatusLists");
+      jsiToValue<FfiList_ObjectHandle>(rt, options, "revocationStatusLists", true);
 
   int8_t resultP;
 
@@ -501,20 +415,20 @@ jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
   auto attributeRawValues =
       jsiToValue<FfiStrList>(rt, options, "attributeRawValues");
   auto attributeEncodedValues =
-      jsiToValue<FfiStrList>(rt, options, "attributeEncodedValues");
+      jsiToValue<FfiStrList>(rt, options, "attributeEncodedValues", true);
   auto revocationRegistryId =
-      jsiToValue<std::string>(rt, options, "revocationRegistryId");
+      jsiToValue<std::string>(rt, options, "revocationRegistryId", true);
   auto revocationStatusList =
-      jsiToValue<ObjectHandle>(rt, options, "revocationStatusList");
-  auto revocation = jsiToValue<FfiCredRevInfo>(rt, options, "revocation");
+      jsiToValue<ObjectHandle>(rt, options, "revocationStatusList", true);
+  auto revocation = jsiToValue<FfiCredRevInfo>(rt, options, "revocationConfiguration", true);
 
   ObjectHandle credP;
 
   ErrorCode code = anoncreds_create_credential(
       credentialDefinition, credentialDefinitionPrivate, credentialOffer,
       credentialRequest, attributeNames, attributeRawValues,
-      attributeEncodedValues, revocationRegistryId.c_str(),
-      revocationStatusList, &revocation, &credP);
+      attributeEncodedValues, revocationRegistryId.length() > 0 ? revocationRegistryId.c_str() : nullptr,
+      revocationStatusList, revocation.reg_def ? &revocation : 0, &credP);
   handleError(rt, code);
 
   return jsi::Value(int(credP));

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
@@ -28,6 +28,7 @@ jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options);
 jsi::Value revocationRegistryDefinitionFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value revocationRegistryFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value presentationRequestFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value credentialOfferFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value schemaFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value masterSecretFromJson(jsi::Runtime &rt, jsi::Object options);

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
@@ -24,6 +24,23 @@ jsi::Value generateNonce(jsi::Runtime &rt, jsi::Object options);
 jsi::Value createSchema(jsi::Runtime &rt, jsi::Object options);
 jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options);
 
+// Anoncreds Objects from JSON
+jsi::Value revocationRegistryDefinitionFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value revocationRegistryFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialOfferFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value schemaFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value masterSecretFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialRequestFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialRequestMetadataFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value revocationRegistryDefinitionPrivateFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value revocationStateFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value revocationRegistryDeltaFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialDefinitionFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value credentialDefinitionPrivateFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value keyCorrectnessProofFromJson(jsi::Runtime &rt, jsi::Object options);
+
 // Proofs
 jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options);
 jsi::Value verifyPresentation(jsi::Runtime &rt, jsi::Object options);

--- a/wrappers/javascript/anoncreds-react-native/cpp/include/libanoncreds.h
+++ b/wrappers/javascript/anoncreds-react-native/cpp/include/libanoncreds.h
@@ -347,6 +347,37 @@ ErrorCode anoncreds_verify_presentation(ObjectHandle presentation,
                                         struct FfiList_ObjectHandle rev_status_list,
                                         int8_t *result_p);
 
+ErrorCode anoncreds_master_secret_from_json(ByteBuffer buffer, ObjectHandle *master_secret_p);
+
+ErrorCode anoncreds_credential_from_json(ByteBuffer buffer, ObjectHandle *credential_p);
+
+ErrorCode anoncreds_credential_request_from_json(ByteBuffer buffer, ObjectHandle *credential_request_p);
+
+ErrorCode anoncreds_credential_request_metadata_from_json(ByteBuffer buffer, ObjectHandle *credential_request_metadata_p);
+
+ErrorCode anoncreds_presentation_from_json(ByteBuffer buffer, ObjectHandle *presentation_p);
+
+ErrorCode anoncreds_credential_offer_from_json(ByteBuffer buffer, ObjectHandle *credential_offer_p);
+
+ErrorCode anoncreds_credential_definition_private_from_json(ByteBuffer buffer, ObjectHandle *credential_definition_private_p);
+
+ErrorCode anoncreds_revocation_registry_definition_from_json(ByteBuffer buffer, ObjectHandle *revocation_registry_definition_p);
+
+ErrorCode anoncreds_revocation_registry_from_json(ByteBuffer buffer, ObjectHandle *revocation_registry_p);
+
+ErrorCode anoncreds_revocation_state_from_json(ByteBuffer buffer, ObjectHandle *revocation_state_p);
+
+ErrorCode anoncreds_credential_definition_from_json(ByteBuffer buffer, ObjectHandle *credential_definition_p);
+
+ErrorCode anoncreds_revocation_registry_definition_private_from_json(ByteBuffer buffer, ObjectHandle *revocation_registry_private_p);
+
+ErrorCode anoncreds_revocation_registry_delta_from_json(ByteBuffer buffer, ObjectHandle *revocation_registry_delta_p);
+
+ErrorCode anoncreds_key_correctness_proof_from_json(ByteBuffer buffer, ObjectHandle *key_correctness_proof_p);
+
+ErrorCode anoncreds_schema_from_json(ByteBuffer buffer, ObjectHandle *schema_p);
+
+
 char *anoncreds_version(void);
 
 #ifdef __cplusplus

--- a/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
@@ -64,6 +64,9 @@ int8_t jsiToValue(jsi::Runtime &rt, jsi::Object &options, const char *name,
   if (value.isNumber())
     return value.asNumber();
 
+  if (value.isBool())
+      return value.asBool() ? 1 : 0;
+
   throw jsi::JSError(rt, errorPrefix + name + errorInfix + "number");
 };
 
@@ -163,7 +166,7 @@ FfiCredentialEntry jsiToValue(jsi::Runtime &rt, jsi::Object &options,
     auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp", true);
     auto revocationState =
         jsiToValue<ObjectHandle>(rt, valueAsObject, "rev_state", true);
-  
+
     return FfiCredentialEntry{.credential = credential,
                               .timestamp = timestamp,
                               .rev_state = revocationState};
@@ -214,9 +217,9 @@ jsiToValue<FfiList_FfiCredentialEntry>(jsi::Runtime &rt, jsi::Object &options,
 
       auto credential =
           jsiToValue<ObjectHandle>(rt, valueAsObject, "credential");
-      auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp");
+      auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp", true);
       auto revocationState =
-          jsiToValue<ObjectHandle>(rt, valueAsObject, "revocationState");
+          jsiToValue<ObjectHandle>(rt, valueAsObject, "rev_state", true);
 
       credentialEntry[i] = *new FfiCredentialEntry[sizeof(FfiCredentialEntry)];
       credentialEntry[i] = FfiCredentialEntry{.credential = credential,
@@ -255,10 +258,13 @@ jsiToValue<FfiList_FfiCredentialProve>(jsi::Runtime &rt, jsi::Object &options,
       auto isPredicate = jsiToValue<int8_t>(rt, valueAsObject, "isPredicate");
       auto reveal = jsiToValue<int8_t>(rt, valueAsObject, "reveal");
 
+      char *ffiStr = new char[sizeof(referent)];
+      strcpy(ffiStr, referent.c_str());
+        
       credentialProve[i] = *new FfiCredentialProve[sizeof(FfiCredentialProve)];
       credentialProve[i] = FfiCredentialProve{.entry_idx = entryIndex,
                                               .is_predicate = isPredicate,
-                                              .referent = referent.c_str(),
+                                              .referent = ffiStr,
                                               .reveal = reveal};
     }
     return FfiList_FfiCredentialProve{.count = len, .data = credentialProve};
@@ -309,6 +315,9 @@ FfiList_FfiStr jsiToValue<FfiList_FfiStr>(jsi::Runtime &rt,
     auto arr = value.asObject(rt).asArray(rt);
     auto len = arr.length(rt);
 
+    if (len == 0) {
+      return FfiList_FfiStr{};
+    }
     char **ffiStr = new char *[len];
 
     for (int i = 0; i < len; i++) {

--- a/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
@@ -165,7 +165,7 @@ FfiCredentialEntry jsiToValue(jsi::Runtime &rt, jsi::Object &options,
     auto credential = jsiToValue<ObjectHandle>(rt, valueAsObject, "credential");
     auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp", true);
     auto revocationState =
-        jsiToValue<ObjectHandle>(rt, valueAsObject, "rev_state", true);
+        jsiToValue<ObjectHandle>(rt, valueAsObject, "revocationState", true);
 
     return FfiCredentialEntry{.credential = credential,
                               .timestamp = timestamp,
@@ -219,7 +219,7 @@ jsiToValue<FfiList_FfiCredentialEntry>(jsi::Runtime &rt, jsi::Object &options,
           jsiToValue<ObjectHandle>(rt, valueAsObject, "credential");
       auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp", true);
       auto revocationState =
-          jsiToValue<ObjectHandle>(rt, valueAsObject, "rev_state", true);
+          jsiToValue<ObjectHandle>(rt, valueAsObject, "revocationState", true);
 
       credentialEntry[i] = *new FfiCredentialEntry[sizeof(FfiCredentialEntry)];
       credentialEntry[i] = FfiCredentialEntry{.credential = credential,

--- a/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
@@ -160,10 +160,10 @@ FfiCredentialEntry jsiToValue(jsi::Runtime &rt, jsi::Object &options,
   if (value.isObject()) {
     jsi::Object valueAsObject = value.asObject(rt);
     auto credential = jsiToValue<ObjectHandle>(rt, valueAsObject, "credential");
-    auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp");
+    auto timestamp = jsiToValue<int64_t>(rt, valueAsObject, "timestamp", true);
     auto revocationState =
-        jsiToValue<ObjectHandle>(rt, valueAsObject, "revocationState");
-
+        jsiToValue<ObjectHandle>(rt, valueAsObject, "rev_state", true);
+  
     return FfiCredentialEntry{.credential = credential,
                               .timestamp = timestamp,
                               .rev_state = revocationState};

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -156,7 +156,6 @@ export class ReactNativeAnoncreds implements Anoncreds {
     const schemaValues = Object.values(options.schemas).map((o) => o.handle)
     const credentialDefinitionKeys = Object.keys(options.credentialDefinitions)
     const credentialDefinitionValues = Object.values(options.credentialDefinitions).map((o) => o.handle)
-    const serialized = serializeArguments(options)
 
     const credentialEntries = options.credentials.map((value) => ({
       credential: value.credential.handle,
@@ -165,7 +164,9 @@ export class ReactNativeAnoncreds implements Anoncreds {
     }))
 
     const handle = anoncredsReactNative.createPresentation({
-      ...serialized,
+      presentationRequest: options.presentationRequest.handle,
+      masterSecret: options.masterSecret.handle,
+      credentialsProve: options.credentialsProve,
       selfAttestNames,
       selfAttestValues,
       credentials: credentialEntries,

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -150,12 +150,25 @@ export class ReactNativeAnoncreds implements Anoncreds {
     schemas: Record<string, ObjectHandle>
     credentialDefinitions: Record<string, ObjectHandle>
   }): ObjectHandle {
+    const selfAttestNames = Object.keys(options.selfAttest)
+    const selfAttestValues = Object.values(options.selfAttest)
     const schemaKeys = Object.keys(options.schemas)
     const schemaValues = Object.values(options.schemas).map((o) => o.handle)
     const credentialDefinitionKeys = Object.keys(options.credentialDefinitions)
     const credentialDefinitionValues = Object.values(options.credentialDefinitions).map((o) => o.handle)
+    const serialized = serializeArguments(options)
+
+    const credentialEntries = options.credentials.map((value) => ({
+      credential: value.credential.handle,
+      timestamp: value.timestamp ?? -1,
+      rev_state: value.revocationState?.handle ?? 0,
+    }))
+
     const handle = anoncredsReactNative.createPresentation({
-      ...serializeArguments(options),
+      ...serialized,
+      selfAttestNames,
+      selfAttestValues,
+      credentials: credentialEntries,
       schemas: schemaValues,
       schemaIds: schemaKeys,
       credentialDefinitions: credentialDefinitionValues,
@@ -260,7 +273,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
   }
 
   public credentialOfferFromJson(options: { json: string }): ObjectHandle {
-    const handle = anoncredsReactNative.credentialFromJson(serializeArguments(options))
+    const handle = anoncredsReactNative.credentialOfferFromJson(serializeArguments(options))
     return new ObjectHandle(handle)
   }
 

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -183,7 +183,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
     const credentialEntries = options.credentials.map((value) => ({
       credential: value.credential.handle,
       timestamp: value.timestamp ?? -1,
-      rev_state: value.revocationState?.handle ?? 0,
+      revocationState: value.revocationState?.handle ?? 0,
     }))
 
     const handle = anoncredsReactNative.createPresentation({

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -87,9 +87,31 @@ export class ReactNativeAnoncreds implements Anoncreds {
     credentialRequest: ObjectHandle
     attributeRawValues: Record<string, string>
     attributeEncodedValues?: Record<string, string>
+    revocationRegistryId?: string
+    revocationStatusList?: ObjectHandle
     revocationConfiguration?: NativeCredentialRevocationConfig
   }): ObjectHandle {
-    const { credential } = anoncredsReactNative.createCredential(serializeArguments(options))
+    const attributeNames = Object.keys(options.attributeRawValues)
+    const attributeRawValues = Object.values(options.attributeRawValues)
+    const attributeEncodedValues = options.attributeEncodedValues
+      ? Object.values(options.attributeEncodedValues)
+      : undefined
+
+    const credential = anoncredsReactNative.createCredential({
+      ...serializeArguments(options),
+      attributeRawValues,
+      attributeEncodedValues,
+      attributeNames,
+      revocationConfiguration: options.revocationConfiguration
+        ? {
+            registryIndex: options.revocationConfiguration.registryIndex,
+            revocationRegistryDefinition: options.revocationConfiguration.revocationRegistryDefinition.handle,
+            revocationRegistryDefinitionPrivate:
+              options.revocationConfiguration.revocationRegistryDefinitionPrivate.handle,
+            tailsPath: options.revocationConfiguration.tailsPath,
+          }
+        : undefined,
+    })
 
     return new ObjectHandle(credential)
   }
@@ -186,8 +208,8 @@ export class ReactNativeAnoncreds implements Anoncreds {
     credentialDefinitions: ObjectHandle[]
     credentialDefinitionIds: string[]
     revocationRegistryDefinitions?: ObjectHandle[]
-    revocationRegistryDefinitionIds: string[]
-    revocationStatusLists: ObjectHandle[]
+    revocationRegistryDefinitionIds?: string[]
+    revocationStatusLists?: ObjectHandle[]
   }): boolean {
     return anoncredsReactNative.verifyPresentation(serializeArguments(options))
   }

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -67,7 +67,7 @@ export interface NativeBindings {
   createMasterSecret(options: Record<never, never>): number
   createPresentation(options: {
     presentationRequest: number
-    credentials: { credential: number; timestamp?: number; rev_state?: number }[]
+    credentials: { credential: number; timestamp?: number; revocationState?: number }[]
     credentialsProve: NativeCredentialProve[]
     selfAttestNames: string[]
     selfAttestValues: string[]

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -1,8 +1,4 @@
-import type {
-  NativeCredentialEntry,
-  NativeCredentialProve,
-  NativeCredentialRevocationConfig,
-} from '@hyperledger/anoncreds-shared'
+import type { NativeCredentialProve } from '@hyperledger/anoncreds-shared'
 
 // Alias for _Handle.handle
 type _Handle = number
@@ -39,10 +35,18 @@ export interface NativeBindings {
     credentialDefinitionPrivate: number
     credentialOffer: number
     credentialRequest: number
-    attributeRawValues: string
-    attributeEncodedValues?: string
-    revocationConfiguration?: NativeCredentialRevocationConfig
-  }): { credential: _Handle; revocationRegistry: _Handle; revocationDelta: _Handle }
+    attributeNames: string[]
+    attributeRawValues: string[]
+    attributeEncodedValues?: string[]
+    revocationRegistryId?: string
+    revocationStatusList?: number
+    revocationConfiguration?: {
+      registryIndex: number
+      revocationRegistryDefinition: number
+      revocationRegistryDefinitionPrivate: number
+      tailsPath: string
+    }
+  }): _Handle
   encodeCredentialAttributes(options: { attributeRawValues: Array<string> }): string
   processCredential(options: {
     credential: number

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -62,9 +62,10 @@ export interface NativeBindings {
   createMasterSecret(options: Record<never, never>): number
   createPresentation(options: {
     presentationRequest: number
-    credentials: NativeCredentialEntry[]
+    credentials: { credential: number; timestamp?: number; rev_state?: number }[]
     credentialsProve: NativeCredentialProve[]
-    selfAttest: string
+    selfAttestNames: string[]
+    selfAttestValues: string[]
     masterSecret: number
     schemaIds: string[]
     schemas: number[]


### PR DESCRIPTION
Adding the missing methods from react-native wrappers and making lots of minor fixes, mostly related to typos and outdated variable/method names.

At the moment working for a full issuance / present proof / verify proof flow without revocation (yes, also possible to issue a credential in React Native 🎉). However there is a memory leak leading to custom app crashes and variable corruption (!) when creating presentation.  Based on some debugging I did, the corrupted variables are strings in some FFI lists: it seems that strings are cleared or updated by the runtime before they are used by native library. Not sure if this makes sense, but I noticed that if I use short strings for fields like `issuerId`, `schemaId` and `credentialDefinitionId` (e.g. _'mock:uri'_) the flow works fine consistently, while if I use relatively long strings (real full DIDs, 50 characters long or so, no matter if it's only one of these variables), the flow crashes almost always. 🤔 

Also I think in some methods (like the aforementioned `createPresentation`) we are missing data deallocation but not completely sure how to handle that yet (@blu3beri you have all lottery numbers for this prize!! 😄). Work done in #129 will certainly help but I don't think if it's enough in a long-term app session. 

PS: All getXXXFromJson methods can be heavily refactored as they do almost the same thing. For the moment just wanted to be conservative to be focused in solving all issues, but any suggestion to make it cleaner will be appreciated!