### PR TITLE
feat(js): revocation status list from json

### DIFF
--- a/src/ffi/revocation.rs
+++ b/src/ffi/revocation.rs
@@ -219,7 +219,10 @@ impl_anoncreds_object_from_json!(
 );
 
 impl_anoncreds_object!(RevocationStatusList, "RevocationStatusList");
-impl_anoncreds_object_from_json!(RevocationStatusList, anoncreds_revocation_status_list_from_json);
+impl_anoncreds_object_from_json!(
+    RevocationStatusList,
+    anoncreds_revocation_status_list_from_json
+);
 
 #[no_mangle]
 pub extern "C" fn anoncreds_create_or_update_revocation_state(

--- a/src/ffi/revocation.rs
+++ b/src/ffi/revocation.rs
@@ -219,7 +219,7 @@ impl_anoncreds_object_from_json!(
 );
 
 impl_anoncreds_object!(RevocationStatusList, "RevocationStatusList");
-impl_anoncreds_object_from_json!(RevocationStatusList, anoncreds_revocation_list_from_json);
+impl_anoncreds_object_from_json!(RevocationStatusList, anoncreds_revocation_status_list_from_json);
 
 #[no_mangle]
 pub extern "C" fn anoncreds_create_or_update_revocation_state(

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -652,6 +652,10 @@ export class NodeJSAnoncreds implements Anoncreds {
     return this.objectFromJson(this.nativeAnoncreds.anoncreds_revocation_registry_from_json, options)
   }
 
+  public revocationStatusListFromJson(options: { json: string }): ObjectHandle {
+    return this.objectFromJson(this.nativeAnoncreds.anoncreds_revocation_status_list_from_json, options)
+  }
+
   public revocationStateFromJson(options: { json: string }): ObjectHandle {
     return this.objectFromJson(this.nativeAnoncreds.anoncreds_revocation_state_from_json, options)
   }

--- a/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
@@ -167,6 +167,7 @@ export const nativeBindings = {
   anoncreds_credential_offer_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],
   anoncreds_revocation_registry_definition_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],
   anoncreds_revocation_registry_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],
+  anoncreds_revocation_status_list_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],
   anoncreds_revocation_state_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],
   anoncreds_credential_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],
   anoncreds_credential_definition_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],

--- a/wrappers/javascript/anoncreds-react-native/cpp/HostObject.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/HostObject.cpp
@@ -45,6 +45,8 @@ FunctionMap AnoncredsTurboModuleHostObject::functionMapping(jsi::Runtime &rt) {
       std::make_tuple("setDefaultLogger", &anoncreds::setDefaultLogger));
   fMap.insert(
       std::make_tuple("verifyPresentation", &anoncreds::verifyPresentation));
+fMap.insert(std::make_tuple("createRevocationStatusList",
+                              &anoncreds::createRevocationStatusList));
   fMap.insert(std::make_tuple("updateRevocationStatusList",
                               &anoncreds::updateRevocationStatusList));
   fMap.insert(std::make_tuple("objectFree", &anoncreds::objectFree));
@@ -54,6 +56,12 @@ FunctionMap AnoncredsTurboModuleHostObject::functionMapping(jsi::Runtime &rt) {
   fMap.insert(
       std::make_tuple("revocationRegistryDefinitionFromJson",
                       &anoncreds::revocationRegistryDefinitionFromJson));
+  fMap.insert(
+      std::make_tuple("revocationRegistryFromJson",
+                      &anoncreds::revocationRegistryDefinitionFromJson));
+  fMap.insert(
+      std::make_tuple("revocationStatusListFromJson",
+                      &anoncreds::revocationStatusListFromJson));
   fMap.insert(std::make_tuple("presentationFromJson",
                               &anoncreds::presentationFromJson));
   fMap.insert(std::make_tuple("presentationRequestFromJson",

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -153,6 +153,24 @@ jsi::Value revocationRegistryFromJson(jsi::Runtime &rt, jsi::Object options) {
   return returnValue;
 };
 
+jsi::Value revocationStatusListFromJson(jsi::Runtime &rt,
+                                                jsi::Object options) {
+  auto json = jsiToValue<std::string>(rt, options, "json");
+
+  ObjectHandle out;
+
+  ByteBuffer b = stringToByteBuffer(json);
+  ErrorCode code = anoncreds_revocation_status_list_from_json(b, &out);
+
+  auto returnValue = createReturnValue(rt, code, &out);
+
+  // free data
+  delete[] b.data;
+
+  return returnValue;
+};
+
+
 jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options) {
   auto json = jsiToValue<std::string>(rt, options, "json");
 

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.h
@@ -44,6 +44,7 @@ jsi::Value createCredentialDefinition(jsi::Runtime &rt, jsi::Object options);
 jsi::Value revocationRegistryDefinitionFromJson(jsi::Runtime &rt,
                                                 jsi::Object options);
 jsi::Value revocationRegistryFromJson(jsi::Runtime &rt, jsi::Object options);
+jsi::Value revocationStatusListFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value presentationFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value presentationRequestFromJson(jsi::Runtime &rt, jsi::Object options);
 jsi::Value credentialOfferFromJson(jsi::Runtime &rt, jsi::Object options);

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -300,12 +300,17 @@ export class ReactNativeAnoncreds implements Anoncreds {
   }
 
   public revocationRegistryDefinitionFromJson(options: { json: string }): ObjectHandle {
-    const handle = handleError(anoncredsReactNative.revocationRegistryFromJson(serializeArguments(options)))
+    const handle = handleError(anoncredsReactNative.revocationRegistryDefinitionFromJson(serializeArguments(options)))
     return new ObjectHandle(handle)
   }
 
   public revocationRegistryFromJson(options: { json: string }): ObjectHandle {
     const handle = handleError(anoncredsReactNative.revocationRegistryFromJson(serializeArguments(options)))
+    return new ObjectHandle(handle)
+  }
+
+  public revocationStatusListFromJson(options: { json: string }): ObjectHandle {
+    const handle = handleError(anoncredsReactNative.revocationStatusListFromJson(serializeArguments(options)))
     return new ObjectHandle(handle)
   }
 

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -159,6 +159,8 @@ export interface NativeBindings {
 
   revocationRegistryFromJson(options: { json: string }): ReturnObject<Handle>
 
+  revocationStatusListFromJson(options: { json: string }): ReturnObject<Handle>
+
   presentationFromJson(options: { json: string }): ReturnObject<Handle>
 
   credentialOfferFromJson(options: { json: string }): ReturnObject<Handle>

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -173,6 +173,8 @@ export interface Anoncreds {
 
   revocationRegistryFromJson(options: { json: string }): ObjectHandle
 
+  revocationStatusListFromJson(options: { json: string }): ObjectHandle
+
   presentationFromJson(options: { json: string }): ObjectHandle
 
   credentialOfferFromJson(options: { json: string }): ObjectHandle

--- a/wrappers/javascript/anoncreds-shared/src/api/Presentation.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/Presentation.ts
@@ -1,7 +1,6 @@
 import type { ObjectHandle } from '../ObjectHandle'
 import type { JsonObject } from '../types'
 import type { RevocationRegistry } from './RevocationRegistry'
-import type { RevocationStatusList } from './RevocationStatusList'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
@@ -11,6 +10,7 @@ import { CredentialDefinition } from './CredentialDefinition'
 import { CredentialRevocationState } from './CredentialRevocationState'
 import { PresentationRequest } from './PresentationRequest'
 import { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
+import { RevocationStatusList } from './RevocationStatusList'
 import { Schema } from './Schema'
 import { pushToArray } from './utils'
 
@@ -57,7 +57,7 @@ export type VerifyPresentationOptions = {
   schemas: Record<string, Schema | JsonObject>
   credentialDefinitions: Record<string, CredentialDefinition | JsonObject>
   revocationRegistryDefinitions?: Record<string, RevocationRegistryDefinition | JsonObject>
-  revocationStatusLists?: RevocationStatusList[]
+  revocationStatusLists?: Array<RevocationStatusList | JsonObject>
   nonRevokedIntervalOverride?: NonRevokedIntervalOverride[]
 }
 
@@ -163,7 +163,11 @@ export class Presentation extends AnoncredsObject {
             : pushToArray(RevocationRegistryDefinition.fromJson(o).handle, objectHandles)
         ),
         revocationRegistryDefinitionIds,
-        revocationStatusLists: options.revocationStatusLists?.map((o) => o.handle),
+        revocationStatusLists: options.revocationStatusLists?.map((o) =>
+          o instanceof RevocationStatusList
+            ? o.handle
+            : pushToArray(RevocationStatusList.fromJson(o).handle, objectHandles)
+        ),
         nonRevokedIntervalOverride: options.nonRevokedIntervalOverride,
       })
     } finally {

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
@@ -50,22 +50,7 @@ export class RevocationStatusList extends AnoncredsObject {
   }
 
   public static fromJson(json: JsonObject) {
-    let revocationRegistryDefinition: RevocationRegistryDefinition | undefined = undefined
-    try {
-      revocationRegistryDefinition = RevocationRegistryDefinition.fromJson(
-        json.revocationRegistryDefinition as JsonObject
-      )
-      const revocationStatusList = RevocationStatusList.create({
-        issuanceByDefault: json.issuanceByDefault as boolean,
-        issuerId: json.issuerId as string,
-        revocationRegistryDefinitionId: json.revocationRegistryDefinitionId as string,
-        timestamp: json.timestamp as number,
-        revocationRegistryDefinition,
-      })
-      return revocationStatusList
-    } finally {
-      revocationRegistryDefinition?.handle.clear()
-    }
+    return new RevocationStatusList(anoncreds.revocationStatusListFromJson({ json: JSON.stringify(json) }).handle)
   }
 
   public updateTimestamp(options: UpdateRevocationStatusListTimestampOptions) {

--- a/wrappers/python/anoncreds/types.py
+++ b/wrappers/python/anoncreds/types.py
@@ -602,7 +602,7 @@ class RevocationStatusList(bindings.AnoncredsObject):
     @classmethod
     def load(cls, value: Union[dict, str, bytes, memoryview]) -> "RevocationStatusList":
         return RevocationStatusList(
-            bindings._object_from_json("anoncreds_revocation_list_from_json", value)
+            bindings._object_from_json("anoncreds_revocation_status_list_from_json", value)
         )
 
     def update_timestamp_only(self, timestamp: int):


### PR DESCRIPTION
This add support to create a revocation status list from json in the JS wrapper. The method was already availalbe in the ffi layer as `anoncreds_revocation_list_from_json`, but I changed it to `anoncreds_revocation_status_list_from_json` as that aligns more with the rest of the naming. If we choose to call it `revocation_list` we should change it everywhere at once.

Also fixes a few small issues in the RN wrapper.