### PR TITLE
fix(rn): link secret is string instead of object

### DIFF
--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -56,7 +56,7 @@ jsi::Value objectFree(jsi::Runtime &rt, jsi::Object options) {
 // ===== META =====
 
 jsi::Value createLinkSecret(jsi::Runtime &rt, jsi::Object options) {
-  ObjectHandle out;
+  const char *out;
 
   ErrorCode code = anoncreds_create_link_secret(&out);
 
@@ -364,7 +364,7 @@ jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
       jsiToValue<FfiStrList>(rt, options, "selfAttestNames");
   auto selfAttestedValues =
       jsiToValue<FfiStrList>(rt, options, "selfAttestValues");
-  auto linkSecret = jsiToValue<ObjectHandle>(rt, options, "linkSecret");
+  auto linkSecret = jsiToValue<std::string>(rt, options, "linkSecret");
   auto schemas = jsiToValue<FfiList_ObjectHandle>(rt, options, "schemas");
   auto schemaIds = jsiToValue<FfiList_FfiStr>(rt, options, "schemaIds");
   auto credentialDefinitions =
@@ -376,7 +376,7 @@ jsi::Value createPresentation(jsi::Runtime &rt, jsi::Object options) {
 
   ErrorCode code = anoncreds_create_presentation(
       presentationRequest, credentials, credentialsProve, selfAttestedNames,
-      selfAttestedValues, linkSecret, schemas, schemaIds,
+      selfAttestedValues, linkSecret.c_str(), schemas, schemaIds,
       credentialDefinitions, credentialDefinitionIds, &out);
 
   auto returnValue = createReturnValue(rt, code, &out);
@@ -504,7 +504,7 @@ jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options) {
   auto proverDid = jsiToValue<std::string>(rt, options, "proverDid", true);
   auto credentialDefinition =
       jsiToValue<ObjectHandle>(rt, options, "credentialDefinition");
-  auto linkSecret = jsiToValue<ObjectHandle>(rt, options, "linkSecret");
+  auto linkSecret = jsiToValue<std::string>(rt, options, "linkSecret");
   auto linkSecretId = jsiToValue<std::string>(rt, options, "linkSecretId");
   auto credentialOffer =
       jsiToValue<ObjectHandle>(rt, options, "credentialOffer");
@@ -514,7 +514,7 @@ jsi::Value createCredentialRequest(jsi::Runtime &rt, jsi::Object options) {
   ErrorCode code = anoncreds_create_credential_request(
       entropy.length() ? entropy.c_str() : nullptr,
       proverDid.length() ? proverDid.c_str() : nullptr, credentialDefinition,
-      linkSecret, linkSecretId.c_str(), credentialOffer,
+      linkSecret.c_str(), linkSecretId.c_str(), credentialOffer,
       &out.credentialRequest, &out.credentialRequestMetadata);
 
   return createReturnValue(rt, code, &out);
@@ -548,7 +548,7 @@ jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
   auto credential = jsiToValue<ObjectHandle>(rt, options, "credential");
   auto credentialRequestMetadata =
       jsiToValue<ObjectHandle>(rt, options, "credentialRequestMetadata");
-  auto linkSecret = jsiToValue<ObjectHandle>(rt, options, "linkSecret");
+  auto linkSecret = jsiToValue<std::string>(rt, options, "linkSecret");
   auto credentialDefinition =
       jsiToValue<ObjectHandle>(rt, options, "credentialDefinition");
   auto revocationRegistryDefinition = jsiToValue<ObjectHandle>(
@@ -557,7 +557,7 @@ jsi::Value processCredential(jsi::Runtime &rt, jsi::Object options) {
   ObjectHandle out;
 
   ErrorCode code = anoncreds_process_credential(
-      credential, credentialRequestMetadata, linkSecret, credentialDefinition,
+      credential, credentialRequestMetadata, linkSecret.c_str(), credentialDefinition,
       revocationRegistryDefinition, &out);
 
   return createReturnValue(rt, code, &out);


### PR DESCRIPTION
Link secret has changed from object to just a string, but this wasn't reflected in the C++ layer