### PR TITLE
fix(js): inconsistencies in create revocation state

### DIFF
--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -580,14 +580,14 @@ export class NodeJSAnoncreds implements Anoncreds {
     revocationStatusList: ObjectHandle
     revocationRegistryIndex: number
     tailsPath: string
-    previousRevocationStatusList?: ObjectHandle
-    previousRevocationState?: ObjectHandle
+    oldRevocationState?: ObjectHandle
+    oldRevocationStatusList?: ObjectHandle
   }): ObjectHandle {
     const { revocationRegistryDefinition, revocationStatusList, revocationRegistryIndex, tailsPath } =
       serializeArguments(options)
 
-    const previousRevocationState = options.previousRevocationState ?? new ObjectHandle(0)
-    const previousRevocationStatusList = options.previousRevocationStatusList ?? new ObjectHandle(0)
+    const oldRevocationState = options.oldRevocationState ?? new ObjectHandle(0)
+    const oldRevocationStatusList = options.oldRevocationStatusList ?? new ObjectHandle(0)
     const ret = allocatePointer()
 
     this.nativeAnoncreds.anoncreds_create_or_update_revocation_state(
@@ -595,14 +595,15 @@ export class NodeJSAnoncreds implements Anoncreds {
       revocationStatusList,
       revocationRegistryIndex,
       tailsPath,
-      previousRevocationStatusList.handle,
-      previousRevocationState.handle,
+      oldRevocationState.handle,
+      oldRevocationStatusList.handle,
       ret
     )
     this.handleError()
 
     return new ObjectHandle(handleReturnPointer<number>(ret))
   }
+
   public version(): string {
     return this.nativeAnoncreds.anoncreds_version()
   }

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -592,16 +592,16 @@ jsi::Value createOrUpdateRevocationState(jsi::Runtime &rt,
   auto revocationRegistryIndex =
       jsiToValue<int64_t>(rt, options, "revocationRegistryIndex");
   auto tailsPath = jsiToValue<std::string>(rt, options, "tailsPath");
-  auto revocationState =
-      jsiToValue<ObjectHandle>(rt, options, "revocationState");
+  auto oldRevocationState =
+      jsiToValue<ObjectHandle>(rt, options, "oldRevocationState", true);
   auto oldRevocationStatusList =
-      jsiToValue<ObjectHandle>(rt, options, "oldRevocationStatusList");
+      jsiToValue<ObjectHandle>(rt, options, "oldRevocationStatusList", true);
 
   ObjectHandle out;
 
   ErrorCode code = anoncreds_create_or_update_revocation_state(
       revocationRegistryDefinition, revocationStatusList,
-      revocationRegistryIndex, tailsPath.c_str(), revocationState,
+      revocationRegistryIndex, tailsPath.c_str(), oldRevocationState,
       oldRevocationStatusList, &out);
 
   return createReturnValue(rt, code, &out);

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -257,9 +257,10 @@ export class ReactNativeAnoncreds implements Anoncreds {
 
   public createOrUpdateRevocationState(options: {
     revocationRegistryDefinition: ObjectHandle
+    revocationStatusList: ObjectHandle
     revocationRegistryIndex: number
     tailsPath: string
-    revocationState?: number
+    oldRevocationState?: ObjectHandle
     oldRevocationStatusList?: ObjectHandle
   }): ObjectHandle {
     const handle = handleError(anoncredsReactNative.createOrUpdateRevocationState(serializeArguments(options)))

--- a/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/library/NativeBindings.ts
@@ -133,9 +133,10 @@ export interface NativeBindings {
 
   createOrUpdateRevocationState(options: {
     revocationRegistryDefinition: number
+    revocationStatusList: number
     revocationRegistryIndex: number
     tailsPath: string
-    revocationState?: number
+    oldRevocationState?: number
     oldRevocationStatusList?: number
   }): ReturnObject<Handle>
 

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -138,7 +138,7 @@ export interface Anoncreds {
     revocationStatusList: ObjectHandle
     revocationRegistryIndex: number
     tailsPath: string
-    previousRevocationState?: ObjectHandle
+    oldRevocationState?: ObjectHandle
     oldRevocationStatusList?: ObjectHandle
   }): ObjectHandle
 

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationState.ts
@@ -15,13 +15,13 @@ export type CreateRevocationStateOptions = {
   revocationRegistryIndex: number
   tailsPath: string
   oldRevocationStatusList?: RevocationRegistryDelta
-  previousRevocationState?: CredentialRevocationState
+  oldRevocationState?: CredentialRevocationState
 }
 
 export type UpdateRevocationStateOptions = Required<
-  Pick<CreateRevocationStateOptions, 'oldRevocationStatusList' | 'previousRevocationState'>
+  Pick<CreateRevocationStateOptions, 'oldRevocationStatusList' | 'oldRevocationState'>
 > &
-  Omit<CreateRevocationStateOptions, 'oldRevocationStatusList' | 'previousRevocationState'>
+  Omit<CreateRevocationStateOptions, 'oldRevocationStatusList' | 'oldRevocationState'>
 
 export class CredentialRevocationState extends AnoncredsObject {
   public static create(options: CreateRevocationStateOptions) {
@@ -48,7 +48,7 @@ export class CredentialRevocationState extends AnoncredsObject {
         revocationRegistryIndex: options.revocationRegistryIndex,
         tailsPath: options.tailsPath,
         oldRevocationStatusList: undefined,
-        previousRevocationState: undefined,
+        oldRevocationState: undefined,
       }).handle
     } finally {
       objectHandles.forEach((handle) => handle.clear())
@@ -67,7 +67,7 @@ export class CredentialRevocationState extends AnoncredsObject {
       revocationRegistryIndex: options.revocationRegistryIndex,
       tailsPath: options.tailsPath,
       oldRevocationStatusList: options.oldRevocationStatusList.handle,
-      previousRevocationState: options.previousRevocationState.handle,
+      oldRevocationState: options.oldRevocationState.handle,
     })
   }
 }


### PR DESCRIPTION
Fixes some inconsistencies and issues encountered when testing proving of revocable credentials. There's probably a few things that are broken in the verification / issuance as well, but I've mostly focused on the holder role now.