### PR TITLE
fix(js): revocation status list typo and optional timestamp

### DIFF
--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -482,7 +482,7 @@ export class NodeJSAnoncreds implements Anoncreds {
       revocationRegistryDefinitionId,
       revocationRegistryDefinition,
       issuerId,
-      timestamp,
+      timestamp ?? -1,
       issuanceByDefault,
       ret
     )
@@ -520,7 +520,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     const ret = allocatePointer()
 
     this.nativeAnoncreds.anoncreds_update_revocation_status_list(
-      timestamp,
+      timestamp ?? -1,
       issued,
       revoked,
       revocationRegistryDefinition,

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -180,7 +180,6 @@ export class ReactNativeAnoncreds implements Anoncreds {
   }
 
   public createLinkSecret(): string {
-    4
     return handleError(anoncredsReactNative.createLinkSecret({}))
   }
 

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -20,7 +20,11 @@ export class ReactNativeAnoncreds implements Anoncreds {
     timestamp?: number
     issuanceByDefault: boolean
   }): ObjectHandle {
-    const handle = handleError(anoncredsReactNative.createRevocationStatusList(serializeArguments(options)))
+    const handle = handleError(
+      anoncredsReactNative.createRevocationStatusList(
+        serializeArguments({ ...options, timestamp: options.timestamp ?? -1 })
+      )
+    )
     return new ObjectHandle(handle)
   }
 
@@ -176,6 +180,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
   }
 
   public createLinkSecret(): string {
+    4
     return handleError(anoncredsReactNative.createLinkSecret({}))
   }
 

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
@@ -20,7 +20,7 @@ export type UpdateRevocationStatusListTimestampOptions = {
 }
 
 export type UpdateRevocationStatusListOptions = {
-  revocationRegstryDefinition: RevocationRegistryDefinition
+  revocationRegistryDefinition: RevocationRegistryDefinition
   timestamp?: number
   issued?: Array<number>
   revoked?: Array<number>
@@ -65,7 +65,7 @@ export class RevocationStatusList extends AnoncredsObject {
   public update(options: UpdateRevocationStatusListOptions) {
     const updatedRevocationStatusList = anoncreds.updateRevocationStatusList({
       ...options,
-      revocationRegistryDefinition: options.revocationRegstryDefinition.handle,
+      revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
       currentRevocationStatusList: this.handle,
     })
 

--- a/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/RevocationStatusList.ts
@@ -20,7 +20,7 @@ export type UpdateRevocationStatusListTimestampOptions = {
 }
 
 export type UpdateRevocationStatusListOptions = {
-  revocationRegistryDefinition: RevocationRegistryDefinition
+  revocationRegistryDefinition: RevocationRegistryDefinition | JsonObject
   timestamp?: number
   issued?: Array<number>
   revoked?: Array<number>
@@ -63,12 +63,25 @@ export class RevocationStatusList extends AnoncredsObject {
   }
 
   public update(options: UpdateRevocationStatusListOptions) {
-    const updatedRevocationStatusList = anoncreds.updateRevocationStatusList({
-      ...options,
-      revocationRegistryDefinition: options.revocationRegistryDefinition.handle,
-      currentRevocationStatusList: this.handle,
-    })
+    const objectHandles: ObjectHandle[] = []
+    try {
+      const revocationRegistryDefinition =
+        options.revocationRegistryDefinition instanceof RevocationRegistryDefinition
+          ? options.revocationRegistryDefinition.handle
+          : pushToArray(
+              RevocationRegistryDefinition.fromJson(options.revocationRegistryDefinition).handle,
+              objectHandles
+            )
 
-    this.handle = updatedRevocationStatusList
+      const updatedRevocationStatusList = anoncreds.updateRevocationStatusList({
+        ...options,
+        revocationRegistryDefinition,
+        currentRevocationStatusList: this.handle,
+      })
+
+      this.handle = updatedRevocationStatusList
+    } finally {
+      objectHandles.forEach((handle) => handle.clear())
+    }
   }
 }


### PR DESCRIPTION
Some things I found while digging a bit with revocation status lists in JavaScript.

Also, maybe more for a discussion or separate issue, but I find a bit odd to have both `updateTimestamp()` and `update()` methods in `RevocationStatusList` class from JS API. It could be more straightforward to just have `update()` and, if the only defined parameter is the timestamp, it can call `anoncreds.updateRevocationStatusListTimestampOnly`.