### PR TITLE
fix(js): nonRevokedIntervalOverrides naming

### DIFF
--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -425,7 +425,7 @@ export class NodeJSAnoncreds implements Anoncreds {
       credentialDefinitionIds,
     } = serializeArguments(options)
 
-    const nativeNonRevokedIntervalOverride = options.nonRevokedIntervalOverrides?.map((value) => {
+    const nativeNonRevokedIntervalOverrides = options.nonRevokedIntervalOverrides?.map((value) => {
       const { requestedFromTimestamp, revocationRegistryDefinitionId, overrideRevocationStatusListTimestamp } =
         serializeArguments(value)
       return NonRevokedIntervalOverrideStruct({
@@ -437,7 +437,7 @@ export class NodeJSAnoncreds implements Anoncreds {
 
     const nonRevokedIntervalOverrideList = NonRevokedIntervalOverrideListStruct({
       count: options.nonRevokedIntervalOverrides?.length ?? 0,
-      data: nativeNonRevokedIntervalOverride as unknown as TypedArray<
+      data: nativeNonRevokedIntervalOverrides as unknown as TypedArray<
         StructObject<{
           rev_reg_def_id: string
           requested_from_ts: number

--- a/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
@@ -44,7 +44,7 @@ describe('API', () => {
       requested_predicates: {
         predicate1_referent: { name: 'age', p_type: '>=', p_value: 18 },
       },
-      non_revoked: { from: 10, to: 200 },
+      non_revoked: { from: 13, to: 200 },
     })
 
     const schema = Schema.create({
@@ -175,12 +175,30 @@ describe('API', () => {
 
     expect(presentation.handle.handle).toStrictEqual(expect.any(Number))
 
+    // Without revocation timestamp override, it shall fail
+    expect(() => {
+      presentation.verify({
+        presentationRequest,
+        schemas: { ['mock:uri']: schema },
+        credentialDefinitions: { ['mock:uri']: credentialDefinition },
+        revocationRegistryDefinitions: { ['mock:uri']: revocationRegistryDefinition },
+        revocationStatusLists: [revocationStatusList],
+      })
+    }).toThrowError('Invalid timestamp')
+
     const verify = presentation.verify({
       presentationRequest,
       schemas: { ['mock:uri']: schema },
       credentialDefinitions: { ['mock:uri']: credentialDefinition },
       revocationRegistryDefinitions: { ['mock:uri']: revocationRegistryDefinition },
       revocationStatusLists: [revocationStatusList],
+      nonRevokedIntervalOverrides: [
+        {
+          overrideRevocationStatusListTimestamp: 12,
+          requestedFromTimestamp: 13,
+          revocationRegistryDefinitionId: 'mock:uri',
+        },
+      ],
     })
 
     expect(verify).toBeTruthy()

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -117,7 +117,7 @@ export interface Anoncreds {
     revocationRegistryDefinitions?: ObjectHandle[]
     revocationRegistryDefinitionIds?: string[]
     revocationStatusLists?: ObjectHandle[]
-    nonRevokedIntervalOverride?: NativeNonRevokedIntervalOverride[]
+    nonRevokedIntervalOverrides?: NativeNonRevokedIntervalOverride[]
   }): boolean
 
   createRevocationRegistryDefinition(options: {

--- a/wrappers/javascript/anoncreds-shared/src/api/Presentation.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/Presentation.ts
@@ -58,7 +58,7 @@ export type VerifyPresentationOptions = {
   credentialDefinitions: Record<string, CredentialDefinition | JsonObject>
   revocationRegistryDefinitions?: Record<string, RevocationRegistryDefinition | JsonObject>
   revocationStatusLists?: Array<RevocationStatusList | JsonObject>
-  nonRevokedIntervalOverride?: NonRevokedIntervalOverride[]
+  nonRevokedIntervalOverrides?: NonRevokedIntervalOverride[]
 }
 
 export class Presentation extends AnoncredsObject {
@@ -168,7 +168,7 @@ export class Presentation extends AnoncredsObject {
             ? o.handle
             : pushToArray(RevocationStatusList.fromJson(o).handle, objectHandles)
         ),
-        nonRevokedIntervalOverride: options.nonRevokedIntervalOverride,
+        nonRevokedIntervalOverrides: options.nonRevokedIntervalOverrides,
       })
     } finally {
       objectHandles.forEach((handle) => handle.clear())


### PR DESCRIPTION
A very subtle option naming was preventing the non revoked interval overrides to get processed by Rust code: base Anoncreds interface was using `nonRevokedIntervalOverride` while NodeJS and ReactNative implementations are referring to it as `nonRevokedIntervalOverrides` (which makes more sense as it is an array of overrides).

Solves #191 and updates a bit API test to reflect the usage of this parameter.

