### PR TITLE
chore: lower ios compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -402,7 +402,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{matrix.architecture}}
-          path: target/${{matrix.architecture}}/release/libanoncreds.dylib
+          path: target/${{matrix.architecture}}/release/libanoncreds.a
 
   create-ios-xcframework:
     name: Create ios xcframework
@@ -416,7 +416,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Fetch dynamic libraries
+      - name: Fetch static libraries
         uses: actions/download-artifact@v3
       - run: >
           ./build-xcframework.sh aarch64-apple-ios \

--- a/build-xcframework.sh
+++ b/build-xcframework.sh
@@ -12,12 +12,13 @@ fi
 NAME="anoncreds"
 VERSION=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[]  | select(.name == "anoncreds") | .version')
 BUNDLE_IDENTIFIER="org.hyperledger.$NAME"
-LIBRARY_NAME="lib$NAME.dylib"
+LIBRARY_NAME="lib$NAME.a"
 XC_FRAMEWORK_NAME="$NAME.xcframework"
 FRAMEWORK_LIBRARY_NAME="`tr '[:lower:]' '[:upper:]' <<< ${NAME:0:1}`${NAME:1}"
 FRAMEWORK_NAME="$FRAMEWORK_LIBRARY_NAME.framework"
 HEADER_NAME="lib$NAME.h"
 OUT_PATH="out"
+MIN_IOS_VERSION="12.0"
 
 # Setting some default paths
 AARCH64_APPLE_IOS_PATH="./target/aarch64-apple-ios/release"
@@ -156,6 +157,8 @@ cat <<EOT >> Info.plist
 	<string>$VERSION</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
+  <key>MinimumOSVersion</key>
+  <string>$MIN_IOS_VERSION</string>
 </dict>
 </plist>
 EOT
@@ -178,9 +181,5 @@ xcodebuild -create-xcframework \
 
 echo "cleaning up..."
 rm -rf $FRAMEWORK_NAME real sim
-
-echo "Fixing the identifiers of the dylib..."
-install_name_tool -id  @rpath/$NAME.framework/$FRAMEWORK_LIBRARY_NAME $XC_FRAMEWORK_NAME/ios-arm64/$FRAMEWORK_NAME/$FRAMEWORK_LIBRARY_NAME
-install_name_tool -id  @rpath/$NAME.framework/$FRAMEWORK_LIBRARY_NAME $XC_FRAMEWORK_NAME/ios-arm64_x86_64-simulator/$FRAMEWORK_NAME/$FRAMEWORK_LIBRARY_NAME
 
 echo "Framework written to $OUT_PATH/$XC_FRAMEWORK_NAME"


### PR DESCRIPTION
Now using static libraries, which have a lower minimum iOS version suppport, does increase download and possible bundle size (last one is untested).
