### PR TITLE
refactor: services function signatures improvements

### DIFF
--- a/src/data_types/cred_def.rs
+++ b/src/data_types/cred_def.rs
@@ -110,9 +110,9 @@ mod test_cred_def {
     ) {
         let schema = schema();
         issuer::create_credential_definition(
-            "did:example/schema",
+            "did:example/schema".try_into().unwrap(),
             &schema,
-            "did:exampple",
+            "did:exampple".try_into().unwrap(),
             "default-tag",
             SignatureType::CL,
             CredentialDefinitionConfig::default(),
@@ -124,9 +124,9 @@ mod test_cred_def {
     fn should_create_credential_definition() {
         let schema = schema();
         let result = issuer::create_credential_definition(
-            "did:example/schema",
+            "did:example/schema".try_into().unwrap(),
             &schema,
-            "did:exampple",
+            "did:exampple".try_into().unwrap(),
             "default-tag",
             SignatureType::CL,
             CredentialDefinitionConfig::default(),

--- a/src/data_types/cred_def.rs
+++ b/src/data_types/cred_def.rs
@@ -97,7 +97,7 @@ mod test_cred_def {
         issuer::create_schema(
             "name",
             "1.0",
-            "did:example",
+            "did:example".try_into().unwrap(),
             vec!["name".to_owned(), "age".to_owned()].into(),
         )
         .expect("Unable to create Schema")

--- a/src/data_types/cred_request.rs
+++ b/src/data_types/cred_request.rs
@@ -122,13 +122,14 @@ mod cred_req_tests {
     const LINK_SECRET_ID: &str = "link:secret:id";
 
     fn cred_def() -> Result<(CredentialDefinition, CredentialKeyCorrectnessProof)> {
-        let credential_definition_issuer_id = "sample:id";
-
-        let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
         let issuer_id = "sample:uri".try_into()?;
+        let schema_id = "schema:id".try_into()?;
+        let credential_definition_issuer_id = "sample:id".try_into()?;
+        let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
+        
         let schema = create_schema("schema:name", "1.0", issuer_id, attr_names)?;
         let cred_def = create_credential_definition(
-            "schema:id",
+            schema_id,
             &schema,
             credential_definition_issuer_id,
             "default",

--- a/src/data_types/cred_request.rs
+++ b/src/data_types/cred_request.rs
@@ -125,7 +125,8 @@ mod cred_req_tests {
         let credential_definition_issuer_id = "sample:id";
 
         let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
-        let schema = create_schema("schema:name", "1.0", "sample:uri", attr_names)?;
+        let issuer_id = "sample:uri".try_into()?;
+        let schema = create_schema("schema:name", "1.0", issuer_id, attr_names)?;
         let cred_def = create_credential_definition(
             "schema:id",
             &schema,

--- a/src/data_types/cred_request.rs
+++ b/src/data_types/cred_request.rs
@@ -126,7 +126,7 @@ mod cred_req_tests {
         let schema_id = "schema:id".try_into()?;
         let credential_definition_issuer_id = "sample:id".try_into()?;
         let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
-        
+
         let schema = create_schema("schema:name", "1.0", issuer_id, attr_names)?;
         let cred_def = create_credential_definition(
             schema_id,
@@ -152,12 +152,16 @@ mod cred_req_tests {
     ) -> Result<CredentialOffer> {
         if is_legacy {
             create_credential_offer(
-                LEGACY_SCHEMA_IDENTIFIER,
-                LEGACY_CRED_DEF_IDENTIFIER,
+                LEGACY_SCHEMA_IDENTIFIER.try_into()?,
+                LEGACY_CRED_DEF_IDENTIFIER.try_into()?,
                 &correctness_proof,
             )
         } else {
-            create_credential_offer(NEW_IDENTIFIER, NEW_IDENTIFIER, &correctness_proof)
+            create_credential_offer(
+                NEW_IDENTIFIER.try_into()?,
+                NEW_IDENTIFIER.try_into()?,
+                &correctness_proof,
+            )
         }
     }
 

--- a/src/data_types/rev_status_list.rs
+++ b/src/data_types/rev_status_list.rs
@@ -41,12 +41,9 @@ impl TryFrom<&RevocationStatusList> for Option<RevocationRegistry> {
     type Error = Error;
 
     fn try_from(value: &RevocationStatusList) -> std::result::Result<Self, Self::Error> {
-        let value = match value.registry {
-            Some(registry) => Some(RevocationRegistry {
-                value: registry.into(),
-            }),
-            None => None,
-        };
+        let value = value.registry.map(|registry| RevocationRegistry {
+            value: registry.into(),
+        });
 
         Ok(value)
     }

--- a/src/data_types/rev_status_list.rs
+++ b/src/data_types/rev_status_list.rs
@@ -253,7 +253,7 @@ mod rev_reg_tests {
 
         list.update(None, Some(BTreeSet::from([0u32])), None, Some(1245))
             .unwrap();
-        assert_eq!(list.get(0usize).unwrap(), false);
+        assert!(!list.get(0usize).unwrap());
         assert_eq!(list.timestamp().unwrap(), 1245);
     }
 }

--- a/src/data_types/schema.rs
+++ b/src/data_types/schema.rs
@@ -17,6 +17,7 @@ pub struct Schema {
     pub issuer_id: IssuerId,
 }
 
+// QUESTION: If these must be unique, why not directly store them as a set?
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct AttributeNames(pub Vec<String>);
 
@@ -55,11 +56,7 @@ impl Validatable for Schema {
 impl Validatable for AttributeNames {
     fn validate(&self) -> Result<(), ValidationError> {
         let mut unique = HashSet::new();
-        let is_unique = self
-            .0
-            .clone()
-            .into_iter()
-            .all(move |name| unique.insert(name));
+        let is_unique = self.0.iter().all(move |name| unique.insert(name));
 
         if !is_unique {
             return Err("Attributes inside the schema must be unique".into());

--- a/src/ffi/cred_def.rs
+++ b/src/ffi/cred_def.rs
@@ -44,7 +44,7 @@ pub extern "C" fn anoncreds_create_credential_definition(
             .as_opt_str()
             .ok_or_else(|| err_msg!("Missing issuer id"))?
             .try_into()?;
-        
+
         let (cred_def, cred_def_pvt, key_proof) = create_credential_definition(
             schema_id,
             schema.load()?.cast_ref()?,

--- a/src/ffi/cred_def.rs
+++ b/src/ffi/cred_def.rs
@@ -32,7 +32,8 @@ pub extern "C" fn anoncreds_create_credential_definition(
         let tag = tag.as_opt_str().ok_or_else(|| err_msg!("Missing tag"))?;
         let schema_id = schema_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing schema id"))?;
+            .ok_or_else(|| err_msg!("Missing schema id"))?
+            .try_into()?;
         let signature_type = {
             let stype = signature_type
                 .as_opt_str()
@@ -41,7 +42,9 @@ pub extern "C" fn anoncreds_create_credential_definition(
         };
         let issuer_id = issuer_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing issuer id"))?;
+            .ok_or_else(|| err_msg!("Missing issuer id"))?
+            .try_into()?;
+        
         let (cred_def, cred_def_pvt, key_proof) = create_credential_definition(
             schema_id,
             schema.load()?.cast_ref()?,

--- a/src/ffi/cred_offer.rs
+++ b/src/ffi/cred_offer.rs
@@ -15,10 +15,12 @@ pub extern "C" fn anoncreds_create_credential_offer(
         check_useful_c_ptr!(cred_offer_p);
         let schema_id = schema_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing schema ID"))?;
+            .ok_or_else(|| err_msg!("Missing schema ID"))?
+            .try_into()?;
         let cred_def_id = cred_def_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing cred def ID"))?;
+            .ok_or_else(|| err_msg!("Missing cred def ID"))?
+            .try_into()?;
         let cred_offer =
             create_credential_offer(schema_id, cred_def_id, key_proof.load()?.cast_ref()?)?;
         let cred_offer = ObjectHandle::create(cred_offer)?;

--- a/src/ffi/revocation.rs
+++ b/src/ffi/revocation.rs
@@ -132,6 +132,7 @@ pub extern "C" fn anoncreds_update_revocation_status_list_timestamp_only(
 pub extern "C" fn anoncreds_create_revocation_registry_def(
     cred_def: ObjectHandle,
     cred_def_id: FfiStr,
+    _issuer_id: FfiStr, // leaving it here not to break existing code
     tag: FfiStr,
     rev_reg_type: FfiStr,
     max_cred_num: i64,

--- a/src/ffi/revocation.rs
+++ b/src/ffi/revocation.rs
@@ -148,10 +148,12 @@ pub extern "C" fn anoncreds_create_revocation_registry_def(
         let tag = tag.as_opt_str().ok_or_else(|| err_msg!("Missing tag"))?;
         let cred_def_id = cred_def_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing cred def id"))?;
+            .ok_or_else(|| err_msg!("Missing cred def id"))?
+            .try_into()?;
         let issuer_id = issuer_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing issuer id"))?;
+            .ok_or_else(|| err_msg!("Missing issuer id"))?
+            .try_into()?;
         let rev_reg_type = {
             let rtype = rev_reg_type
                 .as_opt_str()

--- a/src/ffi/revocation.rs
+++ b/src/ffi/revocation.rs
@@ -134,7 +134,6 @@ pub extern "C" fn anoncreds_update_revocation_status_list_timestamp_only(
 pub extern "C" fn anoncreds_create_revocation_registry_def(
     cred_def: ObjectHandle,
     cred_def_id: FfiStr,
-    issuer_id: FfiStr,
     tag: FfiStr,
     rev_reg_type: FfiStr,
     max_cred_num: i64,
@@ -150,10 +149,6 @@ pub extern "C" fn anoncreds_create_revocation_registry_def(
             .as_opt_str()
             .ok_or_else(|| err_msg!("Missing cred def id"))?
             .try_into()?;
-        let issuer_id = issuer_id
-            .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing issuer id"))?
-            .try_into()?;
         let rev_reg_type = {
             let rtype = rev_reg_type
                 .as_opt_str()
@@ -164,7 +159,6 @@ pub extern "C" fn anoncreds_create_revocation_registry_def(
         let (reg_def, reg_def_private) = create_revocation_registry_def(
             cred_def.load()?.cast_ref()?,
             cred_def_id,
-            issuer_id,
             tag,
             rev_reg_type,
             max_cred_num

--- a/src/ffi/revocation.rs
+++ b/src/ffi/revocation.rs
@@ -24,7 +24,7 @@ pub extern "C" fn anoncreds_create_revocation_status_list(
     rev_reg_def_id: FfiStr,
     rev_reg_def: ObjectHandle,
     reg_rev_priv: ObjectHandle,
-    issuer_id: FfiStr,
+    _issuer_id: FfiStr, // leaving it here not to break existing code
     issuance_by_default: i8,
     timestamp: i64,
     rev_status_list_p: *mut ObjectHandle,
@@ -33,10 +33,9 @@ pub extern "C" fn anoncreds_create_revocation_status_list(
         check_useful_c_ptr!(rev_status_list_p);
         let rev_reg_def_id = rev_reg_def_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing rev_reg_def_id"))?;
-        let issuer_id = issuer_id
-            .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing issuer_id"))?;
+            .ok_or_else(|| err_msg!("Missing rev_reg_def_id"))?
+            .try_into()?;
+
         let timestamp = if timestamp <= 0 {
             None
         } else {
@@ -48,7 +47,6 @@ pub extern "C" fn anoncreds_create_revocation_status_list(
             rev_reg_def_id,
             rev_reg_def.load()?.cast_ref()?,
             reg_rev_priv.load()?.cast_ref()?,
-            issuer_id,
             issuance_by_default != 0,
             timestamp,
         )?;

--- a/src/ffi/schema.rs
+++ b/src/ffi/schema.rs
@@ -24,7 +24,8 @@ pub extern "C" fn anoncreds_create_schema(
             .ok_or_else(|| err_msg!("Missing schema version"))?;
         let issuer_id = issuer_id
             .as_opt_str()
-            .ok_or_else(|| err_msg!("Missing issuer_id"))?;
+            .ok_or_else(|| err_msg!("Missing issuer_id"))?
+            .try_into()?;
         let schema = create_schema(
             schema_name,
             schema_version,

--- a/src/services/issuer.rs
+++ b/src/services/issuer.rs
@@ -325,23 +325,14 @@ where
 /// ```
 pub fn create_revocation_status_list(
     cred_def: &CredentialDefinition,
-    rev_reg_def_id: impl TryInto<RevocationRegistryDefinitionId, Error = ValidationError>,
+    rev_reg_def_id: RevocationRegistryDefinitionId,
     rev_reg_def: &RevocationRegistryDefinition,
     rev_reg_priv: &RevocationRegistryDefinitionPrivate,
-    issuer_id: impl TryInto<IssuerId, Error = ValidationError>,
     issuance_by_default: bool,
     timestamp: Option<u64>,
 ) -> Result<RevocationStatusList> {
     let max_cred_num = rev_reg_def.value.max_cred_num;
-    let rev_reg_def_id = rev_reg_def_id.try_into()?;
-    let issuer_id = issuer_id.try_into()?;
     let mut rev_reg = RevocationRegistry::from(CLSignaturesRevocationRegistry::empty()?);
-
-    if issuer_id != rev_reg_def.issuer_id {
-        return Err(err_msg!(
-            "Issuer id must be the same as the issuer id in the revocation registry definition"
-        ));
-    }
 
     let list = if issuance_by_default {
         let cred_pub_key = cred_def.get_public_key()?;
@@ -362,7 +353,7 @@ pub fn create_revocation_status_list(
 
     RevocationStatusList::new(
         Some(rev_reg_def_id.to_string().as_str()),
-        issuer_id,
+        rev_reg_def.issuer_id.clone(),
         list,
         Some(rev_reg.into()),
         timestamp,

--- a/src/services/issuer.rs
+++ b/src/services/issuer.rs
@@ -37,11 +37,14 @@ use super::types::{
 ///
 /// ```rust
 /// use anoncreds::issuer;
+/// use anoncreds::data_types::issuer_id::IssuerId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
 ///
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+///
 /// let schema = issuer::create_schema("schema name",
-///                                    "1.0", "did:web:xyz",
+///                                    "1.0", issuer_id,
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 /// ```
@@ -89,18 +92,23 @@ pub fn create_schema(
 /// use anoncreds::issuer;
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id,
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id,
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig::default()
@@ -179,18 +187,25 @@ pub fn create_credential_definition(
 /// use anoncreds::types::SignatureType;
 /// use anoncreds::types::RegistryType;
 /// use anoncreds::tails::TailsFileWriter;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def").expect("Invalid credential definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id,
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id.clone(),
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig {
@@ -201,8 +216,7 @@ pub fn create_credential_definition(
 /// let mut tw = TailsFileWriter::new(None);
 /// let (rev_reg_def, rev_reg_def_priv) =
 ///     issuer::create_revocation_registry_def(&cred_def,
-///                                            "did:web:xyz/resource/cred-def",
-///                                            "did:web:xyz",
+///                                            cred_def_id,
 ///                                            "default-tag",
 ///                                            RegistryType::CL_ACCUM,
 ///                                            1000,
@@ -283,18 +297,27 @@ where
 /// use anoncreds::types::SignatureType;
 /// use anoncreds::types::RegistryType;
 /// use anoncreds::tails::TailsFileWriter;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
+/// use anoncreds::data_types::rev_reg_def::RevocationRegistryDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+/// let rev_reg_def_id = RevocationRegistryDefinitionId::new("did:web:xyz/resource/rev-reg-def").expect("Invalid revocation registry definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id,
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id.clone(),
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig {
@@ -305,8 +328,7 @@ where
 /// let mut tw = TailsFileWriter::new(None);
 /// let (rev_reg_def, rev_reg_def_priv) =
 ///     issuer::create_revocation_registry_def(&cred_def,
-///                                            "did:web:xyz/resource/cred-def",
-///                                            "did:web:xyz",
+///                                            cred_def_id,
 ///                                            "default-tag",
 ///                                            RegistryType::CL_ACCUM,
 ///                                            1000,
@@ -315,10 +337,9 @@ where
 ///
 /// let rev_status_list =
 ///     issuer::create_revocation_status_list(&cred_def,
-///                                           "did:web:xyz/resource/rev-reg-def",
+///                                           rev_reg_def_id,
 ///                                           &rev_reg_def,
 ///                                           &rev_reg_def_priv,
-///                                           "did:web:xyz",
 ///                                           true,
 ///                                           None
 ///                                           ).expect("Unable to create revocation status list");
@@ -373,18 +394,27 @@ pub fn create_revocation_status_list(
 /// use anoncreds::types::SignatureType;
 /// use anoncreds::types::RegistryType;
 /// use anoncreds::tails::TailsFileWriter;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
+/// use anoncreds::data_types::rev_reg_def::RevocationRegistryDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+/// let rev_reg_def_id = RevocationRegistryDefinitionId::new("did:web:xyz/resource/rev-reg-def").expect("Invalid revocation registry definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id,
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id.clone(),
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig {
@@ -395,8 +425,7 @@ pub fn create_revocation_status_list(
 /// let mut tw = TailsFileWriter::new(None);
 /// let (rev_reg_def, rev_reg_def_priv) =
 ///     issuer::create_revocation_registry_def(&cred_def,
-///                                            "did:web:xyz/resource/cred-def",
-///                                            "did:web:xyz",
+///                                            cred_def_id,
 ///                                            "default-tag",
 ///                                            RegistryType::CL_ACCUM,
 ///                                            1000,
@@ -404,10 +433,9 @@ pub fn create_revocation_status_list(
 ///                                            ).expect("Unable to create revocation registry");
 ///
 /// let rev_status_list = issuer::create_revocation_status_list(&cred_def,
-///                                                             "did:web:xyz/resource/rev-reg-def",
+///                                                             rev_reg_def_id,
 ///                                                             &rev_reg_def,
 ///                                                             &rev_reg_def_priv,
-///                                                             "did:web:xyz",
 ///                                                             true,
 ///                                                             None
 ///                                                             ).expect("Unable to create revocation status list");
@@ -434,24 +462,35 @@ pub fn update_revocation_status_list_timestamp_only(
 /// # Example
 ///
 /// ```rust
+/// use std::collections::BTreeSet;
+///
 /// use anoncreds::issuer;
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
 /// use anoncreds::types::RegistryType;
 /// use anoncreds::tails::TailsFileWriter;
-/// use std::collections::BTreeSet;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
+/// use anoncreds::data_types::rev_reg_def::RevocationRegistryDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+/// let rev_reg_def_id = RevocationRegistryDefinitionId::new("did:web:xyz/resource/rev-reg-def").expect("Invalid revocation registry definition ID");
+
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id,
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id.clone(),
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig {
@@ -462,8 +501,7 @@ pub fn update_revocation_status_list_timestamp_only(
 /// let mut tw = TailsFileWriter::new(None);
 /// let (rev_reg_def, rev_reg_def_priv) =
 ///     issuer::create_revocation_registry_def(&cred_def,
-///                                            "did:web:xyz/resource/cred-def",
-///                                            "did:web:xyz",
+///                                            cred_def_id,
 ///                                            "default-tag",
 ///                                            RegistryType::CL_ACCUM,
 ///                                            1000,
@@ -471,10 +509,9 @@ pub fn update_revocation_status_list_timestamp_only(
 ///                                            ).expect("Unable to create revocation registry");
 ///
 /// let rev_status_list = issuer::create_revocation_status_list(&cred_def,
-///                                                             "did:web:xyz/resource/rev-reg-def",
+///                                                             rev_reg_def_id,
 ///                                                             &rev_reg_def,
 ///                                                             &rev_reg_def_priv,
-///                                                             "did:web:xyz",
 ///                                                             true,
 ///                                                             None
 ///                                                             ).expect("Unable to create revocation status list");
@@ -549,26 +586,33 @@ pub fn update_revocation_status_list(
 /// use anoncreds::issuer;
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id.clone(),
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id,
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig::default()
 ///                                          ).expect("Unable to create Credential Definition");
 ///
 /// let credential_offer =
-///     issuer::create_credential_offer("did:web:xyz/resource/schema",
-///                                     "did:web:xyz/resource/cred-def",
+///     issuer::create_credential_offer(schema_id,
+///                                     cred_def_id,
 ///                                     &key_correctness_proof,
 ///                                     ).expect("Unable to create Credential Offer");
 /// ```
@@ -610,26 +654,33 @@ pub fn create_credential_offer(
 ///
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id.clone(),
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id,
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig::default()
 ///                                          ).expect("Unable to create Credential Definition");
 ///
 /// let credential_offer =
-///     issuer::create_credential_offer("did:web:xyz/resource/schema",
-///                                     "did:web:xyz/resource/cred-def",
+///     issuer::create_credential_offer(schema_id,
+///                                     cred_def_id,
 ///                                     &key_correctness_proof,
 ///                                     ).expect("Unable to create Credential Offer");
 ///
@@ -812,39 +863,6 @@ mod tests {
         );
 
         assert!(res.is_ok());
-        Ok(())
-    }
-
-    #[test]
-    fn test_issuer_id_unequal_in_revocation_registry_definiton_and_credential_definition(
-    ) -> Result<()> {
-        let issuer_id = "sample:uri".try_into()?;
-        let schema_id = "schema:id".try_into()?;
-        let cred_def_id = "sample:uri".try_into()?;
-        let credential_definition_issuer_id: IssuerId = "sample:id".try_into()?;
-        let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
-
-        let schema = create_schema("schema:name", "1.0", issuer_id, attr_names)?;
-        let cred_def = create_credential_definition(
-            schema_id,
-            &schema,
-            credential_definition_issuer_id,
-            "default",
-            SignatureType::CL,
-            CredentialDefinitionConfig {
-                support_revocation: true,
-            },
-        )?;
-        let res = create_revocation_registry_def(
-            &cred_def.0,
-            cred_def_id,
-            "default",
-            RegistryType::CL_ACCUM,
-            1,
-            &mut TailsFileWriter::new(None),
-        );
-
-        assert!(res.is_err());
         Ok(())
     }
 

--- a/src/services/issuer.rs
+++ b/src/services/issuer.rs
@@ -45,22 +45,18 @@ use super::types::{
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 /// ```
-pub fn create_schema<II>(
+pub fn create_schema(
     schema_name: &str,
     schema_version: &str,
-    issuer_id: II,
+    issuer_id: IssuerId,
     attr_names: AttributeNames,
-) -> Result<Schema>
-where
-    II: TryInto<IssuerId, Error = ValidationError>,
-{
+) -> Result<Schema> {
     trace!(
         "create_schema >>> schema_name: {}, schema_version: {}, attr_names: {:?}",
         schema_name,
         schema_version,
         attr_names,
     );
-    let issuer_id = issuer_id.try_into()?;
 
     let schema = Schema {
         name: schema_name.to_string(),
@@ -816,7 +812,8 @@ mod tests {
         let revocation_registry_definition_issuer_id = credential_definition_issuer_id;
 
         let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
-        let schema = create_schema("schema:name", "1.0", "sample:uri", attr_names)?;
+        let issuer_id = "sample:uri".try_into()?;
+        let schema = create_schema("schema:name", "1.0", issuer_id, attr_names)?;
         let cred_def = create_credential_definition(
             "schema:id",
             &schema,
@@ -848,7 +845,8 @@ mod tests {
         let revocation_registry_definition_issuer_id = "another:id";
 
         let attr_names = AttributeNames::from(vec!["name".to_owned(), "age".to_owned()]);
-        let schema = create_schema("schema:name", "1.0", "sample:uri", attr_names)?;
+        let issuer_id = "sample:uri".try_into()?;
+        let schema = create_schema("schema:name", "1.0", issuer_id, attr_names)?;
         let cred_def = create_credential_definition(
             "schema:id",
             &schema,

--- a/src/services/prover.rs
+++ b/src/services/prover.rs
@@ -1147,9 +1147,9 @@ mod tests {
         fn _cred_def_and_key_correctness_proof(
         ) -> (CredentialDefinition, CredentialKeyCorrectnessProof) {
             let (cred_def, _, key_correctness_proof) = create_credential_definition(
-                SCHEMA_ID,
+                SCHEMA_ID.try_into().unwrap(),
                 &_schema(),
-                ISSUER_ID,
+                ISSUER_ID.try_into().unwrap(),
                 "tag",
                 SignatureType::CL,
                 CredentialDefinitionConfig {
@@ -1177,9 +1177,9 @@ mod tests {
         fn _legacy_cred_def_and_key_correctness_proof(
         ) -> (CredentialDefinition, CredentialKeyCorrectnessProof) {
             let (cred_def, _, key_correctness_proof) = create_credential_definition(
-                LEGACY_SCHEMA_IDENTIFIER,
+                LEGACY_SCHEMA_IDENTIFIER.try_into().unwrap(),
                 &_legacy_schema(),
-                LEGACY_DID_IDENTIFIER,
+                LEGACY_DID_IDENTIFIER.try_into().unwrap(),
                 "tag",
                 SignatureType::CL,
                 CredentialDefinitionConfig {

--- a/src/services/prover.rs
+++ b/src/services/prover.rs
@@ -62,26 +62,33 @@ pub fn create_link_secret() -> Result<LinkSecret> {
 ///
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id.clone(),
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id,
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig::default()
 ///                                          ).expect("Unable to create Credential Definition");
 ///
 /// let credential_offer =
-///     issuer::create_credential_offer("did:web:xyz/resource/schema",
-///                                     "did:web:xyz/resource/cred-def",
+///     issuer::create_credential_offer(schema_id,
+///                                     cred_def_id,
 ///                                     &key_correctness_proof,
 ///                                     ).expect("Unable to create Credential Offer");
 ///
@@ -169,26 +176,33 @@ pub fn create_credential_request(
 ///
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id.clone(),
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id,
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig::default()
 ///                                          ).expect("Unable to create Credential Definition");
 ///
 /// let credential_offer =
-///     issuer::create_credential_offer("did:web:xyz/resource/schema",
-///                                     "did:web:xyz/resource/cred-def",
+///     issuer::create_credential_offer(schema_id,
+///                                     cred_def_id,
 ///                                     &key_correctness_proof,
 ///                                     ).expect("Unable to create Credential Offer");
 ///
@@ -275,28 +289,33 @@ pub fn process_credential(
 /// use anoncreds::types::PresentCredentials;
 /// use anoncreds::types::CredentialDefinitionConfig;
 /// use anoncreds::types::SignatureType;
+/// use anoncreds::data_types::issuer_id::IssuerId;
 /// use anoncreds::data_types::schema::SchemaId;
 /// use anoncreds::data_types::cred_def::CredentialDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id.clone(),
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id,
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig::default()
 ///                                          ).expect("Unable to create Credential Definition");
 ///
 /// let credential_offer =
-///     issuer::create_credential_offer("did:web:xyz/resource/schema",
-///                                     "did:web:xyz/resource/cred-def",
+///     issuer::create_credential_offer(schema_id,
+///                                     cred_def_id,
 ///                                     &key_correctness_proof,
 ///                                     ).expect("Unable to create Credential Offer");
 ///
@@ -563,18 +582,27 @@ pub fn create_revocation_state_with_witness(
 /// use anoncreds::types::SignatureType;
 /// use anoncreds::types::RegistryType;
 /// use anoncreds::tails::TailsFileWriter;
+/// use anoncreds::data_types::issuer_id::IssuerId;
+/// use anoncreds::data_types::schema::SchemaId;
+/// use anoncreds::data_types::cred_def::CredentialDefinitionId;
+/// use anoncreds::data_types::rev_reg_def::RevocationRegistryDefinitionId;
 ///
 /// let attribute_names: &[&str] = &["name", "age"];
+/// let issuer_id = IssuerId::new("did:web:xyz").expect("Invalid issuer ID");
+/// let schema_id = SchemaId::new("did:web:xyz/resource/schema").expect("Invalid schema ID");
+/// let cred_def_id = CredentialDefinitionId::new("did:web:xyz/resource/cred-def",).expect("Invalid credential definition ID");
+/// let rev_reg_def_id = RevocationRegistryDefinitionId::new("did:web:xyz/resource/rev-reg-def").expect("Invalid revocation registry definition ID");
+///
 /// let schema = issuer::create_schema("schema name",
 ///                                    "1.0",
-///                                    "did:web:xyz",
+///                                    issuer_id.clone(),
 ///                                    attribute_names.into()
 ///                                    ).expect("Unable to create schema");
 ///
 /// let (cred_def, cred_def_priv, key_correctness_proof) =
-///     issuer::create_credential_definition("did:web:xyz/resource/schema",
+///     issuer::create_credential_definition(schema_id.clone(),
 ///                                          &schema,
-///                                          "did:web:xyz",
+///                                          issuer_id.clone(),
 ///                                          "default-tag",
 ///                                          SignatureType::CL,
 ///                                          CredentialDefinitionConfig {
@@ -585,8 +613,7 @@ pub fn create_revocation_state_with_witness(
 /// let mut tw = TailsFileWriter::new(None);
 /// let (rev_reg_def, rev_reg_def_priv) =
 ///     issuer::create_revocation_registry_def(&cred_def,
-///                                            "did:web:xyz/resource/cred-def",
-///                                            "did:web:xyz",
+///                                            cred_def_id,
 ///                                            "default-tag",
 ///                                            RegistryType::CL_ACCUM,
 ///                                            1000,
@@ -595,10 +622,9 @@ pub fn create_revocation_state_with_witness(
 ///
 /// let rev_status_list =
 ///     issuer::create_revocation_status_list(&cred_def,
-///                                           "did:web:xyz/resource/rev-reg-def",
+///                                           rev_reg_def_id,
 ///                                           &rev_reg_def,
 ///                                           &rev_reg_def_priv,
-///                                           "did:web:xyz",
 ///                                           true,
 ///                                           Some(10)
 ///                                           ).expect("Unable to create revocation status list");

--- a/src/services/prover.rs
+++ b/src/services/prover.rs
@@ -1161,7 +1161,12 @@ mod tests {
         }
 
         fn _cred_offer(key_correctness_proof: CredentialKeyCorrectnessProof) -> CredentialOffer {
-            create_credential_offer(SCHEMA_ID, CRED_DEF_ID, &key_correctness_proof).unwrap()
+            create_credential_offer(
+                SCHEMA_ID.try_into().unwrap(),
+                CRED_DEF_ID.try_into().unwrap(),
+                &key_correctness_proof,
+            )
+            .unwrap()
         }
 
         fn _legacy_schema() -> Schema {
@@ -1194,8 +1199,8 @@ mod tests {
             key_correctness_proof: CredentialKeyCorrectnessProof,
         ) -> CredentialOffer {
             create_credential_offer(
-                LEGACY_SCHEMA_IDENTIFIER,
-                LEGACY_CRED_DEF_IDENTIFIER,
+                LEGACY_SCHEMA_IDENTIFIER.try_into().unwrap(),
+                LEGACY_CRED_DEF_IDENTIFIER.try_into().unwrap(),
                 &key_correctness_proof,
             )
             .unwrap()

--- a/src/services/prover.rs
+++ b/src/services/prover.rs
@@ -1135,7 +1135,13 @@ mod tests {
         }
 
         fn _schema() -> Schema {
-            create_schema("test", "1.0", ISSUER_ID, ["a", "b", "c"][..].into()).unwrap()
+            create_schema(
+                "test",
+                "1.0",
+                ISSUER_ID.try_into().unwrap(),
+                ["a", "b", "c"][..].into(),
+            )
+            .unwrap()
         }
 
         fn _cred_def_and_key_correctness_proof(
@@ -1162,7 +1168,7 @@ mod tests {
             create_schema(
                 "test",
                 "1.0",
-                LEGACY_DID_IDENTIFIER,
+                LEGACY_DID_IDENTIFIER.try_into().unwrap(),
                 ["a", "b", "c"][..].into(),
             )
             .unwrap()

--- a/src/utils/query.rs
+++ b/src/utils/query.rs
@@ -2860,9 +2860,9 @@ mod tests {
 
     #[test]
     fn test_old_format_empty() {
-        let json = format!(r#"[]"#);
+        let json = r#"[]"#;
 
-        let query: Query = ::serde_json::from_str(&json).unwrap();
+        let query: Query = ::serde_json::from_str(json).unwrap();
 
         let expected = Query::And(vec![]);
 
@@ -2876,8 +2876,8 @@ mod tests {
         let value1 = _random_string(10);
 
         let json = json!(vec![
-            json ! ({name1.clone(): value1.clone()}),
-            json!({ name2.clone(): ::serde_json::Value::Null })
+            json!({ &name1: value1 }),
+            json!({ name2: ::serde_json::Value::Null })
         ])
         .to_string();
 
@@ -2901,7 +2901,7 @@ mod tests {
     fn test_optimise_or() {
         let json = r#"[]"#;
 
-        let query: Query = ::serde_json::from_str(&json).unwrap();
+        let query: Query = ::serde_json::from_str(json).unwrap();
 
         assert_eq!(query.optimise(), None);
     }

--- a/tests/anoncreds_demos.rs
+++ b/tests/anoncreds_demos.rs
@@ -27,8 +27,8 @@ fn anoncreds_demo_works_for_single_issuer_single_prover() {
 
     // Issuer creates a Credential Offer
     let cred_offer = issuer::create_credential_offer(
-        gvt_schema_id,
-        gvt_cred_def_id,
+        gvt_schema_id.try_into().unwrap(),
+        gvt_cred_def_id.try_into().unwrap(),
         &gvt_cred_key_correctness_proof,
     )
     .expect("Error creating credential offer");
@@ -218,8 +218,8 @@ fn anoncreds_demo_works_with_revocation_for_single_issuer_single_prover() {
 
     // Issuer creates a Credential Offer
     let cred_offer = issuer::create_credential_offer(
-        gvt_schema_id,
-        gvt_cred_def_id,
+        gvt_schema_id.try_into().unwrap(),
+        gvt_cred_def_id.try_into().unwrap(),
         &gvt_cred_key_correctness_proof,
     )
     .expect("Error creating credential offer");
@@ -428,8 +428,8 @@ fn anoncreds_demo_works_for_multiple_issuer_single_prover() {
         fixtures::create_cred_def(&emp_schema, false);
 
     let gvt_cred_offer = issuer::create_credential_offer(
-        gvt_schema_id,
-        gvt_cred_def_id,
+        gvt_schema_id.try_into().unwrap(),
+        gvt_cred_def_id.try_into().unwrap(),
         &gvt_cred_key_correctness_proof,
     )
     .expect("Unable to create credential offer");
@@ -471,8 +471,8 @@ fn anoncreds_demo_works_for_multiple_issuer_single_prover() {
     prover_wallet.credentials.push(gvt_recv_cred);
 
     let emp_cred_offer = issuer::create_credential_offer(
-        emp_schema_id,
-        emp_cred_def_id,
+        emp_schema_id.try_into().unwrap(),
+        emp_cred_def_id.try_into().unwrap(),
         &emp_cred_key_correctness_proof,
     )
     .expect("Unable to create credential offer");
@@ -600,8 +600,8 @@ fn anoncreds_demo_proof_does_not_verify_with_wrong_attr_and_predicates() {
 
     // Issuer creates a Credential Offer
     let cred_offer = issuer::create_credential_offer(
-        gvt_schema_id,
-        gvt_cred_def_id,
+        gvt_schema_id.try_into().unwrap(),
+        gvt_cred_def_id.try_into().unwrap(),
         &gvt_cred_key_correctness_proof,
     )
     .expect("Error creating credential offer");
@@ -729,8 +729,8 @@ fn anoncreds_demo_works_for_requested_attribute_in_upper_case() {
 
     // Issuer creates a Credential Offer
     let cred_offer = issuer::create_credential_offer(
-        gvt_schema_id,
-        gvt_cred_def_id,
+        gvt_schema_id.try_into().unwrap(),
+        gvt_cred_def_id.try_into().unwrap(),
         &gvt_cred_key_correctness_proof,
     )
     .expect("Error creating credential offer");
@@ -907,8 +907,8 @@ fn anoncreds_demo_works_for_twice_entry_of_attribute_from_different_credential()
         fixtures::create_cred_def(&emp_schema, false);
 
     let gvt_cred_offer = issuer::create_credential_offer(
-        gvt_schema_id,
-        gvt_cred_def_id,
+        gvt_schema_id.try_into().unwrap(),
+        gvt_cred_def_id.try_into().unwrap(),
         &gvt_cred_key_correctness_proof,
     )
     .expect("Unable to create credential offer");
@@ -950,8 +950,8 @@ fn anoncreds_demo_works_for_twice_entry_of_attribute_from_different_credential()
     prover_wallet.credentials.push(gvt_recv_cred);
 
     let emp_cred_offer = issuer::create_credential_offer(
-        emp_schema_id,
-        emp_cred_def_id,
+        emp_schema_id.try_into().unwrap(),
+        emp_cred_def_id.try_into().unwrap(),
         &emp_cred_key_correctness_proof,
     )
     .expect("Unable to create credential offer");

--- a/tests/multiple-credentials.rs
+++ b/tests/multiple-credentials.rs
@@ -33,10 +33,10 @@ const SCHEMA_ID_1: &str = "mock:uri:schema1";
 const SCHEMA_ID_2: &str = "mock:uri:schema2";
 const SCHEMA_1: &str = r#"{"name":"gvt","version":"1.0","attrNames":["name","sex","age","height"],"issuerId":"mock:issuer_id/path&q=bar"}"#;
 const SCHEMA_2: &str = r#"{"name":"hogwarts","version":"1.0","attrNames":["wand","house","year"],"issuerId":"mock:issuer_id/path&q=hogwarts"}"#;
-static CRED_DEF_ID_1: &'static str = "mock:uri:1";
-static CRED_DEF_ID_2: &'static str = "mock:uri:2";
-static REV_REG_ID_1: &'static str = "mock:uri:revregid1";
-static REV_REG_ID_2: &'static str = "mock:uri:revregid2";
+static CRED_DEF_ID_1: &str = "mock:uri:1";
+static CRED_DEF_ID_2: &str = "mock:uri:2";
+static REV_REG_ID_1: &str = "mock:uri:revregid1";
+static REV_REG_ID_2: &str = "mock:uri:revregid2";
 
 fn create_request(input: &ReqInput) -> PresentationRequest {
     let nonce = verifier::generate_nonce().unwrap();
@@ -222,7 +222,7 @@ fn anoncreds_with_multiple_credentials_per_request() {
     // [4]: no NRP required
     let reqs: Vec<PresentationRequest> = test_requests_generate()
         .iter()
-        .map(|x| create_request(&x))
+        .map(create_request)
         .collect();
 
     // 1: Issuer setup (credate cred defs, rev defs(optional), cred_offers)

--- a/tests/utils/fixtures.rs
+++ b/tests/utils/fixtures.rs
@@ -89,9 +89,9 @@ pub fn create_cred_def(
     match schema.name.as_str() {
         GVT_SCHEMA_NAME => (
             issuer::create_credential_definition(
-                GVT_SCHEMA_ID,
+                GVT_SCHEMA_ID.try_into().unwrap(),
                 schema,
-                GVT_ISSUER_ID,
+                GVT_ISSUER_ID.try_into().unwrap(),
                 GVT_CRED_DEF_TAG,
                 anoncreds::types::SignatureType::CL,
                 anoncreds::types::CredentialDefinitionConfig { support_revocation },
@@ -101,9 +101,9 @@ pub fn create_cred_def(
         ),
         EMP_SCHEMA_NAME => (
             issuer::create_credential_definition(
-                EMP_SCHEMA_ID,
+                EMP_SCHEMA_ID.try_into().unwrap(),
                 schema,
-                EMP_ISSUER_ID,
+                EMP_ISSUER_ID.try_into().unwrap(),
                 EMP_CRED_DEF_TAG,
                 anoncreds::types::SignatureType::CL,
                 anoncreds::types::CredentialDefinitionConfig { support_revocation },
@@ -129,8 +129,8 @@ pub fn create_rev_reg_def<'a>(
         GVT_CRED_DEF_TAG => (
             issuer::create_revocation_registry_def(
                 cred_def,
-                GVT_CRED_DEF_ID,
-                GVT_ISSUER_ID,
+                GVT_CRED_DEF_ID.try_into().unwrap(),
+                GVT_ISSUER_ID.try_into().unwrap(),
                 GVT_REV_REG_TAG,
                 anoncreds::types::RegistryType::CL_ACCUM,
                 GVT_REV_MAX_CRED_NUM,
@@ -142,8 +142,8 @@ pub fn create_rev_reg_def<'a>(
         EMP_CRED_DEF_TAG => (
             issuer::create_revocation_registry_def(
                 cred_def,
-                EMP_CRED_DEF_ID,
-                EMP_ISSUER_ID,
+                EMP_CRED_DEF_ID.try_into().unwrap(),
+                EMP_ISSUER_ID.try_into().unwrap(),
                 EMP_REV_REG_TAG,
                 anoncreds::types::RegistryType::CL_ACCUM,
                 EMP_REV_MAX_CRED_NUM,

--- a/tests/utils/fixtures.rs
+++ b/tests/utils/fixtures.rs
@@ -164,20 +164,18 @@ pub fn create_revocation_status_list(
     match rev_reg_def.tag.as_str() {
         GVT_REV_REG_TAG => issuer::create_revocation_status_list(
             cred_def,
-            GVT_REV_REG_DEF_ID,
+            GVT_REV_REG_DEF_ID.try_into().unwrap(),
             rev_reg_def,
             rev_reg_priv,
-            GVT_ISSUER_ID,
             issuance_by_default,
             time,
         )
         .expect("Error while creating GVT rev status list"),
         EMP_REV_REG_TAG => issuer::create_revocation_status_list(
             cred_def,
-            EMP_REV_REG_DEF_ID,
+            EMP_REV_REG_DEF_ID.try_into().unwrap(),
             rev_reg_def,
             rev_reg_priv,
-            EMP_ISSUER_ID,
             issuance_by_default,
             time,
         )

--- a/tests/utils/fixtures.rs
+++ b/tests/utils/fixtures.rs
@@ -55,7 +55,7 @@ pub fn create_schema(name: &str) -> (Schema, &str) {
             issuer::create_schema(
                 GVT_SCHEMA_NAME,
                 GVT_SCHEMA_VERSION,
-                GVT_ISSUER_ID,
+                GVT_ISSUER_ID.try_into().unwrap(),
                 GVT_SCHEMA_ATTRIBUTES[..].into(),
             )
             .expect("error while creating GVT schema"),
@@ -65,7 +65,7 @@ pub fn create_schema(name: &str) -> (Schema, &str) {
             issuer::create_schema(
                 EMP_SCHEMA_NAME,
                 EMP_SCHEMA_VERSION,
-                EMP_ISSUER_ID,
+                EMP_ISSUER_ID.try_into().unwrap(),
                 EMP_SCHEMA_ATTRIBUTES[..].into(),
             )
             .expect("error while creating EMP schema"),

--- a/tests/utils/fixtures.rs
+++ b/tests/utils/fixtures.rs
@@ -130,7 +130,6 @@ pub fn create_rev_reg_def<'a>(
             issuer::create_revocation_registry_def(
                 cred_def,
                 GVT_CRED_DEF_ID.try_into().unwrap(),
-                GVT_ISSUER_ID.try_into().unwrap(),
                 GVT_REV_REG_TAG,
                 anoncreds::types::RegistryType::CL_ACCUM,
                 GVT_REV_MAX_CRED_NUM,
@@ -143,7 +142,6 @@ pub fn create_rev_reg_def<'a>(
             issuer::create_revocation_registry_def(
                 cred_def,
                 EMP_CRED_DEF_ID.try_into().unwrap(),
-                EMP_ISSUER_ID.try_into().unwrap(),
                 EMP_REV_REG_TAG,
                 anoncreds::types::RegistryType::CL_ACCUM,
                 EMP_REV_MAX_CRED_NUM,

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -128,9 +128,9 @@ impl<'a> Mock<'a> {
         for (cred_def_id, (schema_id, _, support_revocation, rev_reg_id, _)) in values.iter() {
             let (cred_def_pub, cred_def_priv, cred_def_correctness) =
                 issuer::create_credential_definition(
-                    schema_id.to_string(),
+                    (*schema_id).try_into().unwrap(),
                     &self.ledger.schemas[&SchemaId::new_unchecked(*schema_id)],
-                    issuer_id,
+                    issuer_id.try_into().unwrap(),
                     "tag",
                     SignatureType::CL,
                     CredentialDefinitionConfig {
@@ -154,8 +154,8 @@ impl<'a> Mock<'a> {
                 let mut tf = TailsFileWriter::new(Some(self.tails_path.to_owned()));
                 let (rev_reg_def_pub, rev_reg_def_priv) = issuer::create_revocation_registry_def(
                     &cred_def_pub,
-                    *cred_def_id,
-                    issuer_id,
+                    (*cred_def_id).try_into().unwrap(),
+                    issuer_id.try_into().unwrap(),
                     "some_tag",
                     RegistryType::CL_ACCUM,
                     self.max_cred_num,

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -155,7 +155,6 @@ impl<'a> Mock<'a> {
                 let (rev_reg_def_pub, rev_reg_def_priv) = issuer::create_revocation_registry_def(
                     &cred_def_pub,
                     (*cred_def_id).try_into().unwrap(),
-                    issuer_id.try_into().unwrap(),
                     "some_tag",
                     RegistryType::CL_ACCUM,
                     self.max_cred_num,

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -199,8 +199,8 @@ impl<'a> Mock<'a> {
 
             // Issuer creates a Credential Offer
             let cred_offer = issuer::create_credential_offer(
-                schema_id.to_string(),
-                *cred_def_id,
+                schema_id.to_string().try_into().unwrap(),
+                (*cred_def_id).try_into().unwrap(),
                 &cred_def_correctness,
             )
             .expect("Error creating credential offer");

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -178,10 +178,9 @@ impl<'a> Mock<'a> {
 
                 let revocation_status_list = issuer::create_revocation_status_list(
                     &cred_def_pub,
-                    *rev_reg_id,
+                    (*rev_reg_id).try_into().unwrap(),
                     &rev_reg_def_pub,
                     rev_reg_def_priv,
-                    issuer_id,
                     issuance_by_default,
                     Some(time_now),
                 )

--- a/tests/utils/storage.rs
+++ b/tests/utils/storage.rs
@@ -35,21 +35,12 @@ pub struct Ledger<'a> {
 }
 
 // A struct for keeping all issuer-related objects together
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct IssuerWallet<'a> {
     // cred_def_id: StoredRevDef
     pub cred_defs: HashMap<&'a str, StoredCredDef>,
     // revocation_reg_id: StoredRevDef
     pub rev_defs: HashMap<&'a str, StoredRevDef>,
-}
-
-impl<'a> Default for IssuerWallet<'a> {
-    fn default() -> Self {
-        Self {
-            cred_defs: HashMap::new(),
-            rev_defs: HashMap::new(),
-        }
-    }
 }
 
 // A struct for keeping all issuer-related objects together


### PR DESCRIPTION
This PR is based on #226 .

Small improvements to the `services` module function signatures aiming to make it easier for native consumers to use the library.

Main goal was to get rid of `TryInto<T, Error = ValidationError>` like arguments because that prevented consumers from passing `T` as an argument (because `TryFrom<T> for T` has an `Infallible` error type).

There still are arguments like `&HashMap<&SchemaId, &Schema>` which aren't really straight-forward to fix due to the implications this has in the FFI layer (maps are constructed at runtime from FFI objects references).

Worth looking into would also be `issuer::update_revocation_status_list()` as it's fairly painful to deal with, but I believe that's really more due to the `RevocationRegistryDelta` - `RevocationStatusList` data structures being different and `anoncreds-clsignatures-rs` using the former.