### PR TITLE
Simplify LinkSecret handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ logger = ["env_logger"]
 vendored = ["anoncreds-clsignatures/openssl_vendored"]
 
 [dependencies]
-anoncreds-clsignatures = "0.2.1"
+anoncreds-clsignatures = "0.2.2"
 bs58 = "0.4.0"
 env_logger = { version = "0.9.3", optional = true }
 ffi-support = { version = "0.4.0", optional = true }

--- a/src/data_types/link_secret.rs
+++ b/src/data_types/link_secret.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use crate::cl::{bn::BigNumber, LinkSecret as ClLinkSecret, Prover as CryptoProver};
+use crate::cl::{bn::BigNumber, Prover as CryptoProver};
 use crate::error::ConversionError;
 
 pub struct LinkSecret(pub(crate) BigNumber);
@@ -28,18 +28,6 @@ impl fmt::Debug for LinkSecret {
         f.debug_tuple("LinkSecret")
             .field(if cfg!(test) { &self.0 } else { &"<hidden>" })
             .finish()
-    }
-}
-
-impl From<LinkSecret> for ClLinkSecret {
-    fn from(sec: LinkSecret) -> ClLinkSecret {
-        sec.0.into()
-    }
-}
-
-impl From<ClLinkSecret> for LinkSecret {
-    fn from(sec: ClLinkSecret) -> LinkSecret {
-        Self(sec.into())
     }
 }
 
@@ -79,23 +67,6 @@ mod link_secret_tests {
         let link_secret = LinkSecret::try_from(ls).expect("Error creating link secret");
         let link_secret_str: String = link_secret.try_into().expect("Error creating link secret");
         assert_eq!(link_secret_str, ls);
-    }
-
-    #[test]
-    fn should_convert_between_link_secret() {
-        let link_secret = LinkSecret::new().expect("Unable to create link secret");
-        let cl_link_secret: ClLinkSecret = link_secret
-            .try_clone()
-            .expect("Error cloning link secret")
-            .try_into()
-            .expect("error converting to CL link secret");
-
-        assert_eq!(
-            link_secret.0,
-            cl_link_secret
-                .value()
-                .expect("Error getting value from CL link secret")
-        );
     }
 
     #[test]

--- a/src/services/helpers.rs
+++ b/src/services/helpers.rs
@@ -1,11 +1,12 @@
 use std::collections::HashMap;
 
 use crate::cl::{
-    bn::BigNumber, CredentialSchema, CredentialValues, Issuer, LinkSecret as ClLinkSecret,
-    NonCredentialSchema, SubProofRequest, Verifier,
+    bn::BigNumber, CredentialSchema, CredentialValues, Issuer, NonCredentialSchema,
+    SubProofRequest, Verifier,
 };
 use crate::data_types::{
     credential::AttributeValues,
+    link_secret::LinkSecret,
     nonce::Nonce,
     pres_request::{AttributeInfo, NonRevokedInterval, PredicateInfo, PresentationRequestPayload},
     presentation::RequestedProof,
@@ -46,7 +47,7 @@ pub fn build_non_credential_schema() -> Result<NonCredentialSchema> {
 
 pub fn build_credential_values(
     credential_values: &HashMap<String, AttributeValues>,
-    link_secret: Option<&ClLinkSecret>,
+    link_secret: Option<&LinkSecret>,
 ) -> Result<CredentialValues> {
     trace!(
         "build_credential_values >>> credential_values: {:?}",
@@ -57,9 +58,9 @@ pub fn build_credential_values(
     for (attr, values) in credential_values {
         credential_values_builder.add_dec_known(&attr_common_view(attr), &values.encoded)?;
     }
-    if let Some(ms) = link_secret {
+    if let Some(ls) = link_secret {
         // value is master_secret as that's what's historically been used in published credential definitions
-        credential_values_builder.add_value_hidden("master_secret", &ms.value()?)?;
+        credential_values_builder.add_value_hidden("master_secret", &ls.0)?;
     }
 
     let res = credential_values_builder.finalize()?;

--- a/src/services/prover.rs
+++ b/src/services/prover.rs
@@ -254,8 +254,7 @@ pub fn process_credential(
         &cred_def.value.primary,
         cred_def.value.revocation.as_ref(),
     )?;
-    let credential_values =
-        build_credential_values(&credential.values.0, Some(&link_secret.try_into()?))?;
+    let credential_values = build_credential_values(&credential.values.0, Some(&link_secret))?;
     let rev_pub_key = rev_reg_def.map(|d| &d.value.public_keys.accum_key);
 
     Prover::process_credential_signature(
@@ -454,8 +453,7 @@ pub fn create_presentation(
         )?;
 
         let credential_schema = build_credential_schema(&schema.attr_names.0)?;
-        let credential_values =
-            build_credential_values(&credential.values.0, Some(&link_secret.try_into()?))?;
+        let credential_values = build_credential_values(&credential.values.0, Some(&link_secret))?;
         let (req_attrs, req_predicates) = prepare_credential_for_proving(
             present.requested_attributes,
             present.requested_predicates,


### PR DESCRIPTION
This updates to anoncreds-clsignatures 0.2.2 to take advantage of simple conversion from the link secret to a BigNumber. I don't think there's any reason to support conversion from ClLinkSecret to LinkSecret anymore as the `build_credential_values` method is updated to use LinkSecret.