### PR TITLE
fix(js): free native strings

### DIFF
--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -724,11 +724,13 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.handleError()
 
     const returnValue = handleReturnPointer<{ data: Buffer; len: number }>(ret)
-    const output = new Uint8Array(byteBufferToBuffer(returnValue))
+    const jsonAsArray = new Uint8Array(byteBufferToBuffer(returnValue))
+
+    const output = new TextDecoder().decode(jsonAsArray)
 
     this.nativeAnoncreds.anoncreds_buffer_free(returnValue.data)
 
-    return new TextDecoder().decode(output)
+    return output
   }
 
   public getTypeName(options: { objectHandle: ObjectHandle }) {

--- a/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
@@ -120,6 +120,7 @@ export const nativeBindings = {
   anoncreds_generate_nonce: [FFI_ERRORCODE, [FFI_STRING_PTR]],
   anoncreds_get_current_error: [FFI_ERRORCODE, [FFI_STRING_PTR]],
   anoncreds_object_free: [FFI_VOID, [FFI_OBJECT_HANDLE]],
+  anoncreds_string_free: [FFI_VOID, [FFI_STRING_PTR]],
   anoncreds_object_get_json: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, ByteBufferStructPtr]],
   anoncreds_object_get_type_name: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, FFI_STRING_PTR]],
   anoncreds_presentation_request_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],

--- a/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
@@ -100,6 +100,8 @@ jsi::Value createReturnValue(jsi::Runtime &rt, ErrorCode code,
             ? jsi::Value::null()
             : jsi::String::createFromUtf8(rt, value->data, value->len);
     object.setProperty(rt, "value", valueWithoutNullptr);
+
+    if (value != nullptr) anoncreds_buffer_free(*value);
   }
 
   object.setProperty(rt, "errorCode", int(code));

--- a/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
@@ -49,6 +49,8 @@ jsi::Value createReturnValue(jsi::Runtime &rt, ErrorCode code,
                                    ? jsi::Value::null()
                                    : jsi::String::createFromAscii(rt, *value);
     object.setProperty(rt, "value", valueWithoutNullptr);
+
+    if (!isNullptr) anoncreds_string_free((char *)*value);
   }
 
   object.setProperty(rt, "errorCode", int(code));


### PR DESCRIPTION
Not completely sure if it's the right approach (especially in react-native) but here is a simple attempt to free strings automatically in JS wrappers before returning to the caller, as discussed in https://github.com/hyperledger/anoncreds-rs/issues/236. 