### PR TITLE
Simplify create_credential parameters and remove RevocationRegistryId

### DIFF
--- a/include/libanoncreds.h
+++ b/include/libanoncreds.h
@@ -176,6 +176,7 @@ typedef struct FfiList_FfiStr FfiStrList;
 typedef struct FfiCredRevInfo {
   ObjectHandle reg_def;
   ObjectHandle reg_def_private;
+  ObjectHandle status_list;
   int64_t reg_idx;
 } FfiCredRevInfo;
 
@@ -263,8 +264,6 @@ ErrorCode anoncreds_create_credential(ObjectHandle cred_def,
                                       FfiStrList attr_names,
                                       FfiStrList attr_raw_values,
                                       FfiStrList attr_enc_values,
-                                      FfiStr rev_reg_id,
-                                      ObjectHandle rev_status_list,
                                       const struct FfiCredRevInfo *revocation,
                                       ObjectHandle *cred_p);
 

--- a/src/data_types/credential.rs
+++ b/src/data_types/credential.rs
@@ -5,13 +5,14 @@ use crate::cl::{CredentialSignature, RevocationRegistry, SignatureCorrectnessPro
 use crate::error::{ConversionError, ValidationError};
 use crate::utils::validation::Validatable;
 
-use super::{cred_def::CredentialDefinitionId, rev_reg::RevocationRegistryId, schema::SchemaId};
+use super::rev_reg_def::RevocationRegistryDefinitionId;
+use super::{cred_def::CredentialDefinitionId, schema::SchemaId};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Credential {
     pub schema_id: SchemaId,
     pub cred_def_id: CredentialDefinitionId,
-    pub rev_reg_id: Option<RevocationRegistryId>,
+    pub rev_reg_id: Option<RevocationRegistryDefinitionId>,
     pub values: CredentialValues,
     pub signature: CredentialSignature,
     pub signature_correctness_proof: SignatureCorrectnessProof,
@@ -73,7 +74,7 @@ pub struct CredentialInfo {
     pub attrs: ShortCredentialValues,
     pub schema_id: SchemaId,
     pub cred_def_id: CredentialDefinitionId,
-    pub rev_reg_id: Option<RevocationRegistryId>,
+    pub rev_reg_id: Option<RevocationRegistryDefinitionId>,
     pub cred_rev_id: Option<String>,
 }
 

--- a/src/data_types/macros.rs
+++ b/src/data_types/macros.rs
@@ -44,8 +44,7 @@ macro_rules! impl_anoncreds_object_identifier {
                     "IssuerId" => &LEGACY_DID_IDENTIFIER,
                     "CredentialDefinitionId" => &LEGACY_CRED_DEF_IDENTIFIER,
                     "SchemaId" => &LEGACY_SCHEMA_IDENTIFIER,
-                    // TODO: we do not have correct validation for a revocation registry and definition id
-                    "RevocationRegistryId" => &LEGACY_DID_IDENTIFIER,
+                    // TODO: we do not have correct validation for a revocation registry definition id
                     "RevocationRegistryDefinitionId" => &LEGACY_DID_IDENTIFIER,
                     invalid_name => {
                         return Err($crate::invalid!(

--- a/src/data_types/pres_request.rs
+++ b/src/data_types/pres_request.rs
@@ -118,9 +118,6 @@ impl Serialize for PresentationRequest {
     }
 }
 
-#[allow(unused)]
-pub type PresentationRequestExtraQuery = HashMap<String, Query>;
-
 #[derive(Clone, Default, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct NonRevokedInterval {
     pub from: Option<u64>,

--- a/src/data_types/presentation.rs
+++ b/src/data_types/presentation.rs
@@ -4,7 +4,9 @@ use crate::cl::Proof;
 use crate::error::ValidationError;
 use crate::utils::validation::Validatable;
 
-use super::{cred_def::CredentialDefinitionId, rev_reg::RevocationRegistryId, schema::SchemaId};
+use super::{
+    cred_def::CredentialDefinitionId, rev_reg_def::RevocationRegistryDefinitionId, schema::SchemaId,
+};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Presentation {
@@ -55,7 +57,7 @@ pub struct AttributeValue {
 pub struct Identifier {
     pub schema_id: SchemaId,
     pub cred_def_id: CredentialDefinitionId,
-    pub rev_reg_id: Option<RevocationRegistryId>,
+    pub rev_reg_id: Option<RevocationRegistryDefinitionId>,
     pub timestamp: Option<u64>,
 }
 

--- a/src/data_types/rev_reg.rs
+++ b/src/data_types/rev_reg.rs
@@ -1,7 +1,4 @@
 use crate::cl::RevocationRegistry as CryptoRevocationRegistry;
-use crate::impl_anoncreds_object_identifier;
-
-impl_anoncreds_object_identifier!(RevocationRegistryId);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct RevocationRegistry {

--- a/src/ffi/object.rs
+++ b/src/ffi/object.rs
@@ -202,7 +202,6 @@ impl AnoncredsObjectList {
         Ok(Self(loaded))
     }
 
-    #[allow(unused)]
     pub fn refs<T>(&self) -> Result<Vec<&T>>
     where
         T: AnyAnoncredsObject + 'static,

--- a/src/services/issuer.rs
+++ b/src/services/issuer.rs
@@ -695,8 +695,6 @@ pub fn create_credential_offer(
 ///                               &credential_offer,
 ///                               &credential_request,
 ///                               credential_values.into(),
-///                               None,
-///                               None,
 ///                               None
 ///                               ).expect("Unable to create credential");
 /// ```

--- a/src/services/prover.rs
+++ b/src/services/prover.rs
@@ -228,8 +228,6 @@ pub fn create_credential_request(
 ///                               &credential_offer,
 ///                               &credential_request,
 ///                               credential_values.into(),
-///                               None,
-///                               None,
 ///                               None
 ///                               ).expect("Unable to create credential");
 ///
@@ -341,8 +339,6 @@ pub fn process_credential(
 ///                               &credential_offer,
 ///                               &credential_request,
 ///                               credential_values.into(),
-///                               None,
-///                               None,
 ///                               None
 ///                               ).expect("Unable to create credential");
 ///

--- a/src/services/types.rs
+++ b/src/services/types.rs
@@ -217,6 +217,7 @@ impl Validatable for CredentialRevocationState {
 pub struct CredentialRevocationConfig<'a> {
     pub reg_def: &'a RevocationRegistryDefinition,
     pub reg_def_private: &'a RevocationRegistryDefinitionPrivate,
+    pub status_list: &'a RevocationStatusList,
     pub registry_idx: u32,
 }
 
@@ -224,9 +225,10 @@ impl<'a> std::fmt::Debug for CredentialRevocationConfig<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "CredentialRevocationConfig {{ reg_def: {:?}, private: {:?}, idx: {} }}",
+            "CredentialRevocationConfig {{ reg_def: {:?}, private: {:?}, status_list: {:?}, idx: {} }}",
             self.reg_def,
             secret!(self.reg_def_private),
+            self.status_list,
             secret!(self.registry_idx),
         )
     }

--- a/src/services/verifier.rs
+++ b/src/services/verifier.rs
@@ -863,7 +863,6 @@ fn is_attr_operator(key: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::data_types::rev_reg::RevocationRegistryId;
 
     pub const SCHEMA_ID: &str = "123";
     pub const SCHEMA_NAME: &str = "Schema Name";
@@ -1180,7 +1179,7 @@ mod tests {
                 timestamp: Some(1234),
                 schema_id: SchemaId::default(),
                 cred_def_id: CredentialDefinitionId::default(),
-                rev_reg_id: Some(RevocationRegistryId::default()),
+                rev_reg_id: Some(RevocationRegistryDefinitionId::default()),
             },
         );
         res.insert(
@@ -1189,7 +1188,7 @@ mod tests {
                 timestamp: None,
                 schema_id: SchemaId::default(),
                 cred_def_id: CredentialDefinitionId::default(),
-                rev_reg_id: Some(RevocationRegistryId::default()),
+                rev_reg_id: Some(RevocationRegistryDefinitionId::default()),
             },
         );
         res

--- a/tests/anoncreds_demos.rs
+++ b/tests/anoncreds_demos.rs
@@ -1,5 +1,4 @@
 use anoncreds::data_types::cred_def::CredentialDefinitionId;
-use anoncreds::data_types::rev_reg::RevocationRegistryId;
 use anoncreds::data_types::rev_reg_def::RevocationRegistryDefinitionId;
 use anoncreds::data_types::schema::SchemaId;
 use anoncreds::issuer;
@@ -52,8 +51,6 @@ fn anoncreds_demo_works_for_single_issuer_single_prover() {
         &cred_offer,
         &cred_request,
         cred_values.into(),
-        None,
-        None,
         None,
     )
     .expect("Error creating credential");
@@ -206,7 +203,7 @@ fn anoncreds_demo_works_with_revocation_for_single_issuer_single_prover() {
     let ((gvt_rev_reg_def, gvt_rev_reg_def_priv), gvt_rev_reg_def_id) =
         fixtures::create_rev_reg_def(&gvt_cred_def, &mut tf);
 
-    // Issuer creates reovcation status list - to be put on the ledger
+    // Issuer creates revocation status list - to be put on the ledger
     let time_create_rev_status_list = 12;
     let gvt_revocation_status_list = fixtures::create_revocation_status_list(
         &gvt_cred_def,
@@ -239,7 +236,6 @@ fn anoncreds_demo_works_with_revocation_for_single_issuer_single_prover() {
     let cred_values = fixtures::credential_values("GVT");
 
     let gvt_rev_reg_def_id = RevocationRegistryDefinitionId::new_unchecked(gvt_rev_reg_def_id);
-    let gvt_rev_reg_id = RevocationRegistryId::new_unchecked(gvt_rev_reg_def_id.clone());
 
     // Get the location of the tails_file so it can be read
     let tails_location = gvt_rev_reg_def.value.tails_location.clone();
@@ -250,12 +246,11 @@ fn anoncreds_demo_works_with_revocation_for_single_issuer_single_prover() {
         &cred_offer,
         &cred_request,
         cred_values.into(),
-        Some(gvt_rev_reg_id),
-        Some(&gvt_revocation_status_list),
         Some(CredentialRevocationConfig {
             reg_def: &gvt_rev_reg_def,
             reg_def_private: &gvt_rev_reg_def_priv,
             registry_idx: fixtures::GVT_REV_IDX,
+            status_list: &gvt_revocation_status_list,
         }),
     )
     .expect("Error creating credential");
@@ -452,8 +447,6 @@ fn anoncreds_demo_works_for_multiple_issuer_single_prover() {
         &gvt_cred_request,
         gvt_cred_values.into(),
         None,
-        None,
-        None,
     )
     .expect("Error creating credential");
 
@@ -493,8 +486,6 @@ fn anoncreds_demo_works_for_multiple_issuer_single_prover() {
         &emp_cred_offer,
         &emp_cred_request,
         emp_cred_values.into(),
-        None,
-        None,
         None,
     )
     .expect("Error creating credential");
@@ -624,8 +615,6 @@ fn anoncreds_demo_proof_does_not_verify_with_wrong_attr_and_predicates() {
         &cred_request,
         cred_values.into(),
         None,
-        None,
-        None,
     )
     .expect("Error creating credential");
 
@@ -752,8 +741,6 @@ fn anoncreds_demo_works_for_requested_attribute_in_upper_case() {
         &cred_offer,
         &cred_request,
         cred_values.into(),
-        None,
-        None,
         None,
     )
     .expect("Error creating credential");
@@ -931,8 +918,6 @@ fn anoncreds_demo_works_for_twice_entry_of_attribute_from_different_credential()
         &gvt_cred_request,
         gvt_cred_values.into(),
         None,
-        None,
-        None,
     )
     .expect("Error creating credential");
 
@@ -972,8 +957,6 @@ fn anoncreds_demo_works_for_twice_entry_of_attribute_from_different_credential()
         &emp_cred_offer,
         &emp_cred_request,
         emp_cred_values.into(),
-        None,
-        None,
         None,
     )
     .expect("Error creating credential");

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 pub mod fixtures;
 pub mod mock;
 pub mod storage;

--- a/tests/utils/storage.rs
+++ b/tests/utils/storage.rs
@@ -1,7 +1,6 @@
 use anoncreds::data_types::cred_def::{CredentialDefinition, CredentialDefinitionId};
 use anoncreds::data_types::credential::Credential;
 use anoncreds::data_types::link_secret::LinkSecret;
-use anoncreds::data_types::rev_reg::RevocationRegistryId;
 use anoncreds::data_types::rev_reg_def::{
     RevocationRegistryDefinition, RevocationRegistryDefinitionId,
     RevocationRegistryDefinitionPrivate,
@@ -31,7 +30,7 @@ pub struct Ledger<'a> {
     pub cred_defs: HashMap<CredentialDefinitionId, CredentialDefinition>,
     pub schemas: HashMap<SchemaId, Schema>,
     pub rev_reg_defs: HashMap<RevocationRegistryDefinitionId, RevocationRegistryDefinition>,
-    pub revcation_list: HashMap<&'a str, HashMap<u64, RevocationStatusList>>,
+    pub revocation_list: HashMap<&'a str, HashMap<u64, RevocationStatusList>>,
 }
 
 // A struct for keeping all issuer-related objects together
@@ -47,7 +46,8 @@ pub struct IssuerWallet<'a> {
 #[derive(Debug)]
 pub struct ProverWallet<'a> {
     pub credentials: Vec<Credential>,
-    pub rev_states: HashMap<RevocationRegistryId, (Option<CredentialRevocationState>, Option<u64>)>,
+    pub rev_states:
+        HashMap<RevocationRegistryDefinitionId, (Option<CredentialRevocationState>, Option<u64>)>,
     pub link_secret: LinkSecret,
     pub cred_offers: HashMap<&'a str, CredentialOffer>,
     pub cred_reqs: Vec<(CredentialRequest, CredentialRequestMetadata)>,

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -147,17 +147,10 @@ export class NodeJSAnoncreds implements Anoncreds {
     credentialRequest: ObjectHandle
     attributeRawValues: Record<string, string>
     attributeEncodedValues?: Record<string, string>
-    revocationRegistryId?: string
-    revocationStatusList?: ObjectHandle
     revocationConfiguration?: NativeCredentialRevocationConfig
   }): ObjectHandle {
-    const {
-      credentialDefinition,
-      credentialDefinitionPrivate,
-      credentialOffer,
-      credentialRequest,
-      revocationRegistryId,
-    } = serializeArguments(options)
+    const { credentialDefinition, credentialDefinitionPrivate, credentialOffer, credentialRequest } =
+      serializeArguments(options)
 
     const attributeNames = StringListStruct({
       count: Object.keys(options.attributeRawValues).length,
@@ -178,15 +171,13 @@ export class NodeJSAnoncreds implements Anoncreds {
 
     let revocationConfiguration
     if (options.revocationConfiguration) {
-      const {
-        revocationRegistryDefinition: registryDefinition,
-        revocationRegistryDefinitionPrivate: registryDefinitionPrivate,
-        registryIndex,
-      } = serializeArguments(options.revocationConfiguration)
+      const { revocationRegistryDefinition, revocationRegistryDefinitionPrivate, revocationStatusList, registryIndex } =
+        serializeArguments(options.revocationConfiguration)
 
       revocationConfiguration = CredRevInfoStruct({
-        reg_def: registryDefinition,
-        reg_def_private: registryDefinitionPrivate,
+        reg_def: revocationRegistryDefinition,
+        reg_def_private: revocationRegistryDefinitionPrivate,
+        status_list: revocationStatusList,
         reg_idx: registryIndex,
       })
     }
@@ -200,8 +191,6 @@ export class NodeJSAnoncreds implements Anoncreds {
       attributeNames as unknown as Buffer,
       attributeRawValues as unknown as Buffer,
       attributeEncodedValues as unknown as Buffer,
-      revocationRegistryId,
-      options.revocationStatusList?.handle ?? 0,
       revocationConfiguration?.ref().address() ?? 0,
       credentialPtr
     )

--- a/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -32,12 +32,15 @@ import {
 } from './ffi'
 import { getNativeAnoncreds } from './library'
 
-function handleReturnPointer<Return>(returnValue: Buffer): Return {
+function handleReturnPointer<Return>(returnValue: Buffer, cleanupCallback?: (buffer: Buffer) => void): Return {
   if (returnValue.address() === 0) {
     throw AnoncredsError.customError({ message: 'Unexpected null pointer' })
   }
 
-  return returnValue.deref() as Return
+  const ret = returnValue.deref() as Return
+  if (cleanupCallback) cleanupCallback(returnValue)
+
+  return ret
 }
 
 export class NodeJSAnoncreds implements Anoncreds {
@@ -60,7 +63,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_generate_nonce(ret)
     this.handleError()
 
-    return handleReturnPointer<string>(ret)
+    return handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
   }
 
   public createSchema(options: {
@@ -86,7 +89,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_revocation_registry_definition_get_attribute(objectHandle, name, ret)
     this.handleError()
 
-    return handleReturnPointer<string>(ret)
+    return handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
   }
 
   public credentialGetAttribute(options: { objectHandle: ObjectHandle; name: string }) {
@@ -96,7 +99,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_credential_get_attribute(objectHandle, name, ret)
     this.handleError()
 
-    return handleReturnPointer<string>(ret)
+    return handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
   }
 
   public createCredentialDefinition(options: {
@@ -215,7 +218,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_encode_credential_attributes(attributeRawValues, ret)
     this.handleError()
 
-    const result = handleReturnPointer<string>(ret)
+    const result = handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
 
     return result.split(',')
   }
@@ -296,7 +299,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_create_link_secret(ret)
     this.handleError()
 
-    return handleReturnPointer<string>(ret)
+    return handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
   }
 
   public createPresentation(options: {
@@ -639,7 +642,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_get_current_error(ret)
     this.handleError()
 
-    return handleReturnPointer<string>(ret)
+    return handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
   }
 
   private objectFromJson(method: (byteBuffer: Buffer, ret: Buffer) => unknown, options: { json: string }) {
@@ -721,9 +724,13 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.handleError()
 
     const returnValue = handleReturnPointer<{ data: Buffer; len: number }>(ret)
-    const output = new Uint8Array(byteBufferToBuffer(returnValue))
+    const jsonAsArray = new Uint8Array(byteBufferToBuffer(returnValue))
 
-    return new TextDecoder().decode(output)
+    const output = new TextDecoder().decode(jsonAsArray)
+
+    this.nativeAnoncreds.anoncreds_buffer_free(returnValue.data)
+
+    return output
   }
 
   public getTypeName(options: { objectHandle: ObjectHandle }) {
@@ -734,7 +741,7 @@ export class NodeJSAnoncreds implements Anoncreds {
     this.nativeAnoncreds.anoncreds_object_get_type_name(objectHandle, ret)
     this.handleError()
 
-    return handleReturnPointer<string>(ret)
+    return handleReturnPointer<string>(ret, this.nativeAnoncreds.anoncreds_string_free)
   }
 
   public objectFree(options: { objectHandle: ObjectHandle }) {

--- a/wrappers/javascript/anoncreds-nodejs/src/ffi/structures.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/ffi/structures.ts
@@ -50,6 +50,7 @@ export const I32ListStruct = CStruct({
 export const CredRevInfoStruct = CStruct({
   reg_def: FFI_OBJECT_HANDLE,
   reg_def_private: FFI_OBJECT_HANDLE,
+  status_list: FFI_OBJECT_HANDLE,
   reg_idx: FFI_INT64,
 })
 

--- a/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
@@ -31,8 +31,6 @@ export const nativeBindings = {
       StringListStruct,
       StringListStruct,
       StringListStruct,
-      FFI_STRING,
-      FFI_OBJECT_HANDLE,
       FFI_OBJECT_HANDLE,
       FFI_OBJECT_HANDLE_PTR,
     ],

--- a/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/anoncreds-nodejs/src/library/bindings.ts
@@ -120,6 +120,7 @@ export const nativeBindings = {
   anoncreds_generate_nonce: [FFI_ERRORCODE, [FFI_STRING_PTR]],
   anoncreds_get_current_error: [FFI_ERRORCODE, [FFI_STRING_PTR]],
   anoncreds_object_free: [FFI_VOID, [FFI_OBJECT_HANDLE]],
+  anoncreds_string_free: [FFI_VOID, [FFI_STRING_PTR]],
   anoncreds_object_get_json: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, ByteBufferStructPtr]],
   anoncreds_object_get_type_name: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, FFI_STRING_PTR]],
   anoncreds_presentation_request_from_json: [FFI_ERRORCODE, [ByteBufferStruct, FFI_STRING_PTR]],

--- a/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/api.test.ts
@@ -108,11 +108,10 @@ describe('API', () => {
       credentialOffer,
       credentialRequest,
       attributeRawValues: { name: 'Alex', height: '175', age: '28', sex: 'male' },
-      revocationRegistryId: 'mock:uri',
-      revocationStatusList,
       revocationConfiguration: new CredentialRevocationConfig({
         registryDefinition: revocationRegistryDefinition,
         registryDefinitionPrivate: revocationRegistryDefinitionPrivate,
+        statusList: revocationStatusList,
         registryIndex: 9,
       }),
     })
@@ -431,11 +430,10 @@ test('create and verify presentation passing only JSON objects as parameters', (
     credentialOffer: credentialOffer.toJson(),
     credentialRequest: credentialRequest.toJson(),
     attributeRawValues: { name: 'Alex', height: '175', age: '28', sex: 'male' },
-    revocationRegistryId: 'mock:uri',
-    revocationStatusList: revocationStatusList.toJson(),
     revocationConfiguration: new CredentialRevocationConfig({
       registryDefinition: revocationRegistryDefinition,
       registryDefinitionPrivate: revocationRegistryDefinitionPrivate,
+      statusList: revocationStatusList,
       registryIndex: 9,
     }),
   })

--- a/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
+++ b/wrappers/javascript/anoncreds-nodejs/test/bindings.test.ts
@@ -292,11 +292,10 @@ describe('bindings', () => {
       credentialOffer,
       credentialRequest,
       attributeRawValues: { 'attr-1': 'test' },
-      revocationRegistryId: 'mock:uri',
-      revocationStatusList,
       revocationConfiguration: {
         revocationRegistryDefinition,
         revocationRegistryDefinitionPrivate,
+        revocationStatusList,
         registryIndex: 9,
       },
     })
@@ -428,11 +427,10 @@ describe('bindings', () => {
       credentialOffer,
       credentialRequest,
       attributeRawValues: { name: 'Alex', height: '175', age: '28', sex: 'male' },
-      revocationRegistryId: 'mock:uri',
-      revocationStatusList,
       revocationConfiguration: {
         revocationRegistryDefinition,
         revocationRegistryDefinitionPrivate,
+        revocationStatusList,
         registryIndex: 9,
       },
     })

--- a/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/anoncreds.cpp
@@ -465,10 +465,6 @@ jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
       jsiToValue<FfiStrList>(rt, options, "attributeRawValues");
   auto attributeEncodedValues =
       jsiToValue<FfiStrList>(rt, options, "attributeEncodedValues", true);
-  auto revocationRegistryId =
-      jsiToValue<std::string>(rt, options, "revocationRegistryId", true);
-  auto revocationStatusList =
-      jsiToValue<ObjectHandle>(rt, options, "revocationStatusList", true);
   auto revocation =
       jsiToValue<FfiCredRevInfo>(rt, options, "revocationConfiguration", true);
 
@@ -477,10 +473,7 @@ jsi::Value createCredential(jsi::Runtime &rt, jsi::Object options) {
   ErrorCode code = anoncreds_create_credential(
       credentialDefinition, credentialDefinitionPrivate, credentialOffer,
       credentialRequest, attributeNames, attributeRawValues,
-      attributeEncodedValues,
-      revocationRegistryId.length() > 0 ? revocationRegistryId.c_str()
-                                        : nullptr,
-      revocationStatusList, revocation.reg_def ? &revocation : 0, &out);
+      attributeEncodedValues, revocation.reg_def ? &revocation : 0, &out);
 
   return createReturnValue(rt, code, &out);
 };

--- a/wrappers/javascript/anoncreds-react-native/cpp/include/libanoncreds.h
+++ b/wrappers/javascript/anoncreds-react-native/cpp/include/libanoncreds.h
@@ -176,6 +176,7 @@ typedef struct FfiList_FfiStr FfiStrList;
 typedef struct FfiCredRevInfo {
   ObjectHandle reg_def;
   ObjectHandle reg_def_private;
+  ObjectHandle status_list;
   int64_t reg_idx;
 } FfiCredRevInfo;
 
@@ -263,8 +264,6 @@ ErrorCode anoncreds_create_credential(ObjectHandle cred_def,
                                       FfiStrList attr_names,
                                       FfiStrList attr_raw_values,
                                       FfiStrList attr_enc_values,
-                                      FfiStr rev_reg_id,
-                                      ObjectHandle rev_status_list,
                                       const struct FfiCredRevInfo *revocation,
                                       ObjectHandle *cred_p);
 

--- a/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
+++ b/wrappers/javascript/anoncreds-react-native/cpp/turboModuleUtility.cpp
@@ -49,6 +49,8 @@ jsi::Value createReturnValue(jsi::Runtime &rt, ErrorCode code,
                                    ? jsi::Value::null()
                                    : jsi::String::createFromAscii(rt, *value);
     object.setProperty(rt, "value", valueWithoutNullptr);
+
+    if (!isNullptr) anoncreds_string_free((char *)*value);
   }
 
   object.setProperty(rt, "errorCode", int(code));
@@ -98,6 +100,8 @@ jsi::Value createReturnValue(jsi::Runtime &rt, ErrorCode code,
             ? jsi::Value::null()
             : jsi::String::createFromUtf8(rt, value->data, value->len);
     object.setProperty(rt, "value", valueWithoutNullptr);
+
+    if (value != nullptr) anoncreds_buffer_free(*value);
   }
 
   object.setProperty(rt, "errorCode", int(code));

--- a/wrappers/javascript/anoncreds-react-native/src/NativeBindings.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/NativeBindings.ts
@@ -59,12 +59,11 @@ export interface NativeBindings {
     attributeNames: string[]
     attributeRawValues: string[]
     attributeEncodedValues?: string[]
-    revocationRegistryId?: string
-    revocationStatusList?: number
     revocationConfiguration?: {
       registryIndex: number
       revocationRegistryDefinition: number
       revocationRegistryDefinitionPrivate: number
+      revocationStatusList?: number
     }
   }): ReturnObject<Handle>
   encodeCredentialAttributes(options: { attributeRawValues: Array<string> }): ReturnObject<string>

--- a/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -120,8 +120,6 @@ export class ReactNativeAnoncreds implements Anoncreds {
     credentialRequest: ObjectHandle
     attributeRawValues: Record<string, string>
     attributeEncodedValues?: Record<string, string>
-    revocationRegistryId?: string
-    revocationStatusList?: ObjectHandle
     revocationConfiguration?: NativeCredentialRevocationConfig
   }): ObjectHandle {
     const attributeNames = Object.keys(options.attributeRawValues)
@@ -142,6 +140,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
               revocationRegistryDefinition: options.revocationConfiguration.revocationRegistryDefinition.handle,
               revocationRegistryDefinitionPrivate:
                 options.revocationConfiguration.revocationRegistryDefinitionPrivate.handle,
+              revocationStatusList: options.revocationConfiguration.revocationStatusList.handle,
             }
           : undefined,
       })

--- a/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/anoncreds-shared/src/Anoncreds.ts
@@ -31,6 +31,7 @@ export type NativeRevocationEntry = {
 export type NativeCredentialRevocationConfig = {
   revocationRegistryDefinition: ObjectHandle
   revocationRegistryDefinitionPrivate: ObjectHandle
+  revocationStatusList: ObjectHandle
   registryIndex: number
 }
 
@@ -64,8 +65,6 @@ export interface Anoncreds {
     credentialRequest: ObjectHandle
     attributeRawValues: Record<string, string>
     attributeEncodedValues?: Record<string, string>
-    revocationRegistryId?: string
-    revocationStatusList?: ObjectHandle
     revocationConfiguration?: NativeCredentialRevocationConfig
   }): ObjectHandle
 

--- a/wrappers/javascript/anoncreds-shared/src/api/Credential.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/Credential.ts
@@ -1,6 +1,7 @@
 import type { ObjectHandle } from '../ObjectHandle'
 import type { JsonObject } from '../types'
 import type { CredentialRevocationConfig } from './CredentialRevocationConfig'
+import type { RevocationStatusList } from './RevocationStatusList'
 
 import { AnoncredsObject } from '../AnoncredsObject'
 import { anoncreds } from '../register'
@@ -11,7 +12,6 @@ import { CredentialOffer } from './CredentialOffer'
 import { CredentialRequest } from './CredentialRequest'
 import { CredentialRequestMetadata } from './CredentialRequestMetadata'
 import { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
-import { RevocationStatusList } from './RevocationStatusList'
 import { pushToArray } from './utils'
 
 export type CreateCredentialOptions = {
@@ -59,13 +59,6 @@ export class Credential extends AnoncredsObject {
           ? options.credentialRequest.handle
           : pushToArray(CredentialRequest.fromJson(options.credentialRequest).handle, objectHandles)
 
-      const revocationStatusList =
-        options.revocationStatusList instanceof RevocationStatusList
-          ? options.revocationStatusList.handle
-          : options.revocationStatusList !== undefined
-          ? pushToArray(RevocationStatusList.fromJson(options.revocationStatusList).handle, objectHandles)
-          : undefined
-
       credential = anoncreds.createCredential({
         credentialDefinition,
         credentialDefinitionPrivate,
@@ -73,9 +66,7 @@ export class Credential extends AnoncredsObject {
         credentialRequest,
         attributeRawValues: options.attributeRawValues,
         attributeEncodedValues: options.attributeEncodedValues,
-        revocationRegistryId: options.revocationRegistryId,
         revocationConfiguration: options.revocationConfiguration?.native,
-        revocationStatusList,
       })
     } finally {
       objectHandles.forEach((handle) => handle.clear())

--- a/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationConfig.ts
+++ b/wrappers/javascript/anoncreds-shared/src/api/CredentialRevocationConfig.ts
@@ -1,21 +1,25 @@
 import type { NativeCredentialRevocationConfig } from '../Anoncreds'
 import type { RevocationRegistryDefinition } from './RevocationRegistryDefinition'
 import type { RevocationRegistryDefinitionPrivate } from './RevocationRegistryDefinitionPrivate'
+import type { RevocationStatusList } from './RevocationStatusList'
 
 export type CredentialRevocationConfigOptions = {
   registryDefinition: RevocationRegistryDefinition
   registryDefinitionPrivate: RevocationRegistryDefinitionPrivate
+  statusList: RevocationStatusList
   registryIndex: number
 }
 
 export class CredentialRevocationConfig {
   private registryDefinition: RevocationRegistryDefinition
   private registryDefinitionPrivate: RevocationRegistryDefinitionPrivate
+  private statusList: RevocationStatusList
   private registryIndex: number
 
   public constructor(options: CredentialRevocationConfigOptions) {
     this.registryDefinition = options.registryDefinition
     this.registryDefinitionPrivate = options.registryDefinitionPrivate
+    this.statusList = options.statusList
     this.registryIndex = options.registryIndex
   }
 
@@ -28,6 +32,7 @@ export class CredentialRevocationConfig {
     return {
       revocationRegistryDefinition: this.registryDefinition.handle,
       revocationRegistryDefinitionPrivate: this.registryDefinitionPrivate.handle,
+      revocationStatusList: this.statusList.handle,
       registryIndex: this.registryIndex,
     }
   }

--- a/wrappers/python/anoncreds/types.py
+++ b/wrappers/python/anoncreds/types.py
@@ -2,6 +2,7 @@ from typing import Mapping, Optional, Sequence, Tuple, Union
 
 from . import bindings
 
+
 class CredentialDefinition(bindings.AnoncredsObject):
     GET_ATTR = "anoncreds_credential_definition_get_attribute"
 
@@ -124,7 +125,9 @@ class CredentialRequest(bindings.AnoncredsObject):
             link_secret_id,
             cred_offer.handle,
         )
-        return CredentialRequest(cred_def_handle), CredentialRequestMetadata(cred_def_metadata)
+        return CredentialRequest(cred_def_handle), CredentialRequestMetadata(
+            cred_def_metadata
+        )
 
     @classmethod
     def load(cls, value: Union[dict, str, bytes, memoryview]) -> "CredentialRequest":
@@ -144,6 +147,7 @@ class CredentialRequestMetadata(bindings.AnoncredsObject):
             )
         )
 
+
 class RevocationRegistryDefinition(bindings.AnoncredsObject):
     GET_ATTR = "anoncreds_revocation_registry_definition_get_attribute"
 
@@ -158,10 +162,7 @@ class RevocationRegistryDefinition(bindings.AnoncredsObject):
         max_cred_num: int,
         *,
         tails_dir_path: str = None,
-    ) -> Tuple[
-        "RevocationRegistryDefinition",
-        "RevocationRegistryDefinitionPrivate",
-    ]:
+    ) -> Tuple["RevocationRegistryDefinition", "RevocationRegistryDefinitionPrivate",]:
         if not isinstance(cred_def, bindings.AnoncredsObject):
             cred_def = CredentialDefinition.load(cred_def)
         (
@@ -223,6 +224,7 @@ class RevocationRegistryDefinition(bindings.AnoncredsObject):
             )
         )
 
+
 class Schema(bindings.AnoncredsObject):
     @classmethod
     def create(
@@ -238,6 +240,7 @@ class Schema(bindings.AnoncredsObject):
     def load(cls, value: Union[dict, str, bytes, memoryview]) -> "Schema":
         return Schema(bindings._object_from_json("anoncreds_schema_from_json", value))
 
+
 class Credential(bindings.AnoncredsObject):
     GET_ATTR = "anoncreds_credential_get_attribute"
 
@@ -250,8 +253,6 @@ class Credential(bindings.AnoncredsObject):
         cred_request: Union[str, CredentialRequest],
         attr_raw_values: Mapping[str, str],
         attr_enc_values: Optional[Mapping[str, str]] = None,
-        rev_reg_id: Optional[str] = None,
-        rev_status_list: Optional["RevocationStatusList"] = None,
         revocation_config: Optional["CredentialRevocationConfig"] = None,
     ) -> "Credential":
         if not isinstance(cred_def, bindings.AnoncredsObject):
@@ -269,8 +270,6 @@ class Credential(bindings.AnoncredsObject):
             cred_request.handle,
             attr_raw_values,
             attr_enc_values,
-            rev_reg_id,
-            rev_status_list.handle if rev_status_list else None,
             revocation_config._native if revocation_config else None,
         )
         return Credential(cred)
@@ -278,7 +277,7 @@ class Credential(bindings.AnoncredsObject):
     def process(
         self,
         cred_req_metadata: Union[str, CredentialRequestMetadata],
-        link_secret: str, 
+        link_secret: str,
         cred_def: Union[str, CredentialDefinition],
         rev_reg_def: Optional[Union[str, "RevocationRegistryDefinition"]] = None,
     ) -> "Credential":
@@ -438,15 +437,15 @@ class Presentation(bindings.AnoncredsObject):
         ]
         creds = []
         creds_prove = []
-        for (cred, cred_ts) in present_creds.entries.items():
-            for (timestamp, (attrs, preds, rev_state)) in cred_ts.items():
+        for cred, cred_ts in present_creds.entries.items():
+            for timestamp, (attrs, preds, rev_state) in cred_ts.items():
                 entry_idx = len(creds)
                 creds.append(
                     bindings.CredentialEntry.create(
                         cred, timestamp, rev_state and rev_state
                     )
                 )
-                for (reft, reveal) in attrs:
+                for reft, reveal in attrs:
                     creds_prove.append(
                         bindings.CredentialProve.attribute(entry_idx, reft, reveal)
                     )
@@ -479,9 +478,13 @@ class Presentation(bindings.AnoncredsObject):
         pres_req: Union[str, PresentationRequest],
         schemas: Mapping[str, Union[str, Schema]],
         cred_defs: Mapping[str, Union[str, CredentialDefinition]],
-        rev_reg_defs: Optional[Mapping[str, Union[str, "RevocationRegistryDefinition"]]] = None,
+        rev_reg_defs: Optional[
+            Mapping[str, Union[str, "RevocationRegistryDefinition"]]
+        ] = None,
         rev_status_lists: Optional[Sequence[Union[str, "RevocationStatusList"]]] = None,
-        nonrevoked_interval_overrides: Optional[Sequence["NonrevokedIntervalOverride"]] = None
+        nonrevoked_interval_overrides: Optional[
+            Sequence["NonrevokedIntervalOverride"]
+        ] = None,
     ) -> bool:
         if not isinstance(pres_req, bindings.AnoncredsObject):
             pres_req = PresentationRequest.load(pres_req)
@@ -508,7 +511,9 @@ class Presentation(bindings.AnoncredsObject):
             rev_reg_def_ids = list(rev_reg_defs.keys())
             rev_reg_def_handles = [
                 (
-                    RevocationRegistryDefinition.load(r) if not isinstance(r, bindings.AnoncredsObject) else r
+                    RevocationRegistryDefinition.load(r)
+                    if not isinstance(r, bindings.AnoncredsObject)
+                    else r
                 ).handle
                 for r in rev_reg_defs.values()
             ]
@@ -519,7 +524,9 @@ class Presentation(bindings.AnoncredsObject):
         if rev_status_lists:
             rev_status_list_handles = [
                 (
-                    RevocationStatusList.load(r) if not isinstance(r, bindings.AnoncredsObject) else r
+                    RevocationStatusList.load(r)
+                    if not isinstance(r, bindings.AnoncredsObject)
+                    else r
                 ).handle
                 for r in rev_status_lists
             ]
@@ -564,7 +571,9 @@ class RevocationStatusList(bindings.AnoncredsObject):
         cred_def: Union[dict, str, bytes, CredentialDefinition],
         rev_reg_def_id: str,
         rev_reg_def: Union[dict, str, bytes, RevocationRegistryDefinition],
-        rev_reg_def_private: Union[dict, str, bytes, RevocationRegistryDefinitionPrivate],
+        rev_reg_def_private: Union[
+            dict, str, bytes, RevocationRegistryDefinitionPrivate
+        ],
         issuer_id: str,
         issuance_by_default: bool = True,
         timestamp: Optional[int] = None,
@@ -585,19 +594,27 @@ class RevocationStatusList(bindings.AnoncredsObject):
         )
 
     @classmethod
-    def load(self, value: Union[dict, str, bytes, memoryview]) -> "RevocationStatusList":
+    def load(
+        self, value: Union[dict, str, bytes, memoryview]
+    ) -> "RevocationStatusList":
         return RevocationStatusList(
-            bindings._object_from_json("anoncreds_revocation_status_list_from_json", value)
+            bindings._object_from_json(
+                "anoncreds_revocation_status_list_from_json", value
+            )
         )
 
     def update_timestamp_only(self, timestamp: int):
-        self.handle = bindings.update_revocation_status_list_timestamp_only(timestamp, self.handle)
+        self.handle = bindings.update_revocation_status_list_timestamp_only(
+            timestamp, self.handle
+        )
 
     def update(
         self,
         cred_def: Union[dict, str, bytes, CredentialDefinition],
         rev_reg_def: Union[dict, str, bytes, RevocationRegistryDefinition],
-        rev_reg_def_private: Union[dict, str, bytes, RevocationRegistryDefinitionPrivate],
+        rev_reg_def_private: Union[
+            dict, str, bytes, RevocationRegistryDefinitionPrivate
+        ],
         issued: Optional[Sequence[int]],
         revoked: Optional[Sequence[int]],
         timestamp: Optional[int],
@@ -624,11 +641,13 @@ class RevocationRegistry(bindings.AnoncredsObject):
             bindings._object_from_json("anoncreds_revocation_registry_from_json", value)
         )
 
+
 class CredentialRevocationConfig:
     def __init__(
         self,
         rev_reg_def: Union[str, "RevocationRegistryDefinition"],
         rev_reg_def_private: Union[str, "RevocationRegistryDefinitionPrivate"],
+        rev_status_list: Union[str, "RevocationStatusList"],
         rev_reg_index: int,
     ):
         if not isinstance(rev_reg_def, bindings.AnoncredsObject):
@@ -638,7 +657,10 @@ class CredentialRevocationConfig:
             rev_reg_def_private = RevocationRegistryDefinitionPrivate.load(
                 rev_reg_def_private
             )
+        if not isinstance(rev_status_list, bindings.AnoncredsObject):
+            rev_status_list = RevocationStatusList.load(rev_status_list)
         self.rev_reg_def_private = rev_reg_def_private
+        self.rev_status_list = rev_status_list
         self.rev_reg_index = rev_reg_index
 
     @property
@@ -646,15 +668,17 @@ class CredentialRevocationConfig:
         return bindings.RevocationConfig.create(
             self.rev_reg_def,
             self.rev_reg_def_private,
+            self.rev_status_list,
             self.rev_reg_index,
         )
+
 
 class NonrevokedIntervalOverride:
     def __init__(
         self,
         rev_reg_def_id: str,
         requested_from_ts: int,
-        override_rev_status_list_ts: int
+        override_rev_status_list_ts: int,
     ):
         self.rev_reg_def_id = rev_reg_def_id
         self.requested_from_ts = requested_from_ts
@@ -665,8 +689,9 @@ class NonrevokedIntervalOverride:
         return bindings.NonrevokedIntervalOverride.create(
             self.rev_reg_def_id,
             self.requested_from_ts,
-            self.override_rev_status_list_ts
+            self.override_rev_status_list_ts,
         )
+
 
 class CredentialRevocationState(bindings.AnoncredsObject):
     @classmethod
@@ -688,7 +713,9 @@ class CredentialRevocationState(bindings.AnoncredsObject):
         if rev_state and not isinstance(rev_state, bindings.AnoncredsObject):
             rev_state = CredentialRevocationState.load(rev_state)
 
-        if old_rev_status_list and not isinstance(old_rev_status_list, bindings.AnoncredsObject):
+        if old_rev_status_list and not isinstance(
+            old_rev_status_list, bindings.AnoncredsObject
+        ):
             old_rev_status_list = RevocationStatusList.load(old_rev_status_list)
 
         return CredentialRevocationState(
@@ -722,7 +749,9 @@ class CredentialRevocationState(bindings.AnoncredsObject):
             rev_reg_def = RevocationRegistryDefinition.load(rev_reg_def)
         if not isinstance(rev_status_list, bindings.AnoncredsObject):
             rev_status_list = RevocationStatusList.load(rev_status_list)
-        if old_rev_status_list and not isinstance(old_rev_status_list, bindings.AnoncredsObject):
+        if old_rev_status_list and not isinstance(
+            old_rev_status_list, bindings.AnoncredsObject
+        ):
             old_rev_status_list = RevocationStatusList.load(old_rev_status_list)
 
         self.handle = bindings.create_or_update_revocation_state(
@@ -731,5 +760,5 @@ class CredentialRevocationState(bindings.AnoncredsObject):
             rev_reg_index,
             tails_path,
             self.handle,
-            old_rev_status_list.handle if old_rev_status_list else None
+            old_rev_status_list.handle if old_rev_status_list else None,
         )

--- a/wrappers/python/demo/test.py
+++ b/wrappers/python/demo/test.py
@@ -15,31 +15,23 @@ from anoncreds import (
     Schema,
 )
 
-issuer_id   = "mock:uri"
-schema_id   = "mock:uri"
+issuer_id = "mock:uri"
+schema_id = "mock:uri"
 cred_def_id = "mock:uri"
-rev_reg_id  = "mock:uri:revregid"
-entropy     = "entropy"
+rev_reg_id = "mock:uri:revregid"
+entropy = "entropy"
 rev_idx = 1
 
-schema = Schema.create("schema name", "schema version", issuer_id, ["name","age","sex","height"])
+schema = Schema.create(
+    "schema name", "schema version", issuer_id, ["name", "age", "sex", "height"]
+)
 
 cred_def_pub, cred_def_priv, cred_def_correctness = CredentialDefinition.create(
-    schema_id,
-    schema,
-    issuer_id,
-    "tag",
-    "CL",
-    support_revocation=True
+    schema_id, schema, issuer_id, "tag", "CL", support_revocation=True
 )
 
 (rev_reg_def_pub, rev_reg_def_private) = RevocationRegistryDefinition.create(
-    cred_def_id,
-    cred_def_pub,
-    issuer_id,
-    "some_tag",
-    "CL_ACCUM",
-    10
+    cred_def_id, cred_def_pub, issuer_id, "some_tag", "CL_ACCUM", 10
 )
 
 time_create_rev_status_list = 12
@@ -56,19 +48,10 @@ revocation_status_list = RevocationStatusList.create(
 link_secret = create_link_secret()
 link_secret_id = "default"
 
-cred_offer = CredentialOffer.create(
-    schema_id,
-    cred_def_id,
-    cred_def_correctness
-)
+cred_offer = CredentialOffer.create(schema_id, cred_def_id, cred_def_correctness)
 
 cred_request, cred_request_metadata = CredentialRequest.create(
-    entropy,
-    None,
-    cred_def_pub,
-    link_secret,
-    link_secret_id,
-    cred_offer
+    entropy, None, cred_def_pub, link_secret, link_secret_id, cred_offer
 )
 
 issue_cred = Credential.create(
@@ -76,27 +59,18 @@ issue_cred = Credential.create(
     cred_def_priv,
     cred_offer,
     cred_request,
-    {
-        "sex": "male",
-        "name": "Alex",
-        "height": "175",
-        "age": "28"
-    },
+    {"sex": "male", "name": "Alex", "height": "175", "age": "28"},
     None,
-    rev_reg_id,
-    revocation_status_list,
     CredentialRevocationConfig(
         rev_reg_def_pub,
         rev_reg_def_private,
+        revocation_status_list,
         rev_idx,
     ),
 )
 
 recv_cred = issue_cred.process(
-    cred_request_metadata,
-    link_secret,
-    cred_def_pub,
-    rev_reg_def_pub
+    cred_request_metadata, link_secret, cred_def_pub, rev_reg_def_pub
 )
 
 time_after_creating_cred = time_create_rev_status_list + 1
@@ -113,25 +87,18 @@ nonce = generate_nonce()
 pres_req = PresentationRequest.load(
     {
         "nonce": nonce,
-        "name":"pres_req_1",
-        "version":"0.1",
-        "requested_attributes":{
-            "attr1_referent":{
-                "name":"name",
-                "issuer_id": issuer_id
-            },
-            "attr2_referent":{
-                "name":"sex"
-            },
-            "attr3_referent":{"name":"phone"},
-            "attr4_referent":{
-                "names": ["name", "height"]
-            }
+        "name": "pres_req_1",
+        "version": "0.1",
+        "requested_attributes": {
+            "attr1_referent": {"name": "name", "issuer_id": issuer_id},
+            "attr2_referent": {"name": "sex"},
+            "attr3_referent": {"name": "phone"},
+            "attr4_referent": {"names": ["name", "height"]},
         },
-        "requested_predicates":{
-            "predicate1_referent":{"name":"age","p_type":">=","p_value":18}
+        "requested_predicates": {
+            "predicate1_referent": {"name": "age", "p_type": ">=", "p_value": 18}
         },
-        "non_revoked": {"from": 10, "to": 200}
+        "non_revoked": {"from": 10, "to": 200},
     }
 )
 
@@ -142,9 +109,9 @@ rev_state = CredentialRevocationState.create(
     rev_reg_def_pub.tails_location,
 )
 
-schemas = { schema_id: schema }
-cred_defs = { cred_def_id: cred_def_pub }
-rev_reg_defs = { rev_reg_id: rev_reg_def_pub }
+schemas = {schema_id: schema}
+cred_defs = {cred_def_id: cred_def_pub}
+rev_reg_defs = {rev_reg_id: rev_reg_def_pub}
 rev_status_lists = [issued_rev_status_list]
 
 present = PresentCredentials()
@@ -154,7 +121,7 @@ present.add_attributes(
     "attr1_referent",
     reveal=True,
     timestamp=time_after_creating_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 present.add_attributes(
@@ -162,7 +129,7 @@ present.add_attributes(
     "attr2_referent",
     reveal=False,
     timestamp=time_after_creating_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 present.add_attributes(
@@ -170,14 +137,14 @@ present.add_attributes(
     "attr4_referent",
     reveal=True,
     timestamp=time_after_creating_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 present.add_predicates(
     recv_cred,
     "predicate1_referent",
     timestamp=time_after_creating_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 presentation = Presentation.create(
@@ -190,11 +157,7 @@ presentation = Presentation.create(
 )
 
 verified = presentation.verify(
-    pres_req,
-    schemas,
-    cred_defs,
-    rev_reg_defs,
-    rev_status_lists
+    pres_req, schemas, cred_defs, rev_reg_defs, rev_status_lists
 )
 assert verified
 
@@ -226,7 +189,7 @@ present.add_attributes(
     "attr1_referent",
     reveal=True,
     timestamp=time_revoke_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 present.add_attributes(
@@ -234,7 +197,7 @@ present.add_attributes(
     "attr2_referent",
     reveal=False,
     timestamp=time_revoke_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 present.add_attributes(
@@ -242,23 +205,15 @@ present.add_attributes(
     "attr4_referent",
     reveal=True,
     timestamp=time_revoke_cred,
-    rev_state=rev_state
+    rev_state=rev_state,
 )
 
 present.add_predicates(
-    recv_cred,
-    "predicate1_referent",
-    timestamp=time_revoke_cred,
-    rev_state=rev_state
+    recv_cred, "predicate1_referent", timestamp=time_revoke_cred, rev_state=rev_state
 )
 
 presentation = Presentation.create(
-    pres_req,
-    present,
-    {"attr3_referent": "8-800-300"},
-    link_secret,
-    schemas,
-    cred_defs
+    pres_req, present, {"attr3_referent": "8-800-300"}, link_secret, schemas, cred_defs
 )
 
 verified = presentation.verify(


### PR DESCRIPTION
As far as I understand, there's no such thing as a RevocationRegistryId, since RevocationRegistryDefinitionId covers that usage (for example, see within the Credential structure). Looking at the unit tests they seem to have been used interchangeably. If anything, I think there would need to be a RevocationStatusListId instead. So this PR removes RevocationRegistryId and just uses RevocationRegistryDefinitionId in its place.

When issuing via `create_credential`, the revocation registry definition ID can be taken from the status list object.

The Python wrapper is updated, but I haven't looked at updating the JS wrappers yet.