### PR TITLE
Do not apply prettier to pnpm lockfile

### DIFF
--- a/wrappers/javascript/.prettierignore
+++ b/wrappers/javascript/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/wrappers/javascript/package.json
+++ b/wrappers/javascript/package.json
@@ -17,7 +17,7 @@
     "check-format": "pnpm prettier --list-different",
     "build": "pnpm -r build",
     "clean": "pnpm -r clean",
-    "prettier": "prettier --ignore-path .gitignore '**/*.+(js|json|ts|md|yml|yaml)'",
+    "prettier": "prettier '**/*.+(js|json|ts|md|yml|yaml)'",
     "format": "pnpm prettier --write",
     "validate": "pnpm lint && pnpm check-types && pnpm check-format",
     "shared": "pnpm --cwd anoncreds-shared",


### PR DESCRIPTION
By default prettier ignores paths in .gitignore and .prettierignore, so I've removed the explicit override of ignore-path.