### PR TITLE
Support numbers values in AnonCreds W3C VC

### DIFF
--- a/src/services/w3c/credential_conversion.rs
+++ b/src/services/w3c/credential_conversion.rs
@@ -314,7 +314,7 @@ pub(crate) mod tests {
     pub fn w3c_credential() -> W3CCredential {
         W3CCredential::new(
             issuer_id(),
-            CredentialAttributes::from(&cred_values()),
+            CredentialAttributes::try_from(&cred_values()).unwrap(),
             DataIntegrityProof::new_credential_proof(&credential_signature_proof()).unwrap(),
             None,
         )
@@ -345,9 +345,11 @@ pub(crate) mod tests {
 
         assert_eq!(w3c_credential.context, expected_context.clone());
         assert_eq!(w3c_credential.type_, ANONCREDS_CREDENTIAL_TYPES.clone());
+
+        let expected_attributes = CredentialAttributes::from(&legacy_credential.values);
         assert_eq!(
             w3c_credential.credential_subject.attributes,
-            CredentialAttributes::from(&legacy_credential.values)
+            expected_attributes
         );
 
         let proof = w3c_credential

--- a/src/services/w3c/helpers.rs
+++ b/src/services/w3c/helpers.rs
@@ -19,25 +19,31 @@ impl W3CCredential {
             .ok_or_else(|| err_msg!("Credential attribute {} not found", requested_attribute))
     }
 
-    pub(crate) fn get_attribute(&self, requested_attribute: &str) -> Result<(String, String)> {
+    pub(crate) fn get_attribute(
+        &self,
+        requested_attribute: &str,
+    ) -> Result<(String, CredentialAttributeValue)> {
         let (attribute, value) = self.get_case_insensitive_attribute(requested_attribute)?;
         match value {
-            CredentialAttributeValue::Attribute(value) => Ok((attribute, value)),
-            CredentialAttributeValue::Predicate(_) => Err(err_msg!(
+            CredentialAttributeValue::String(_) => Ok((attribute, value)),
+            CredentialAttributeValue::Number(_) => Ok((attribute, value)),
+            CredentialAttributeValue::Bool(_) => Err(err_msg!(
                 "Credential attribute {} not found",
                 requested_attribute
             )),
         }
     }
 
-    pub(crate) fn get_predicate(&self, requested_predicate: &str) -> Result<(String, bool)> {
+    pub(crate) fn get_predicate(
+        &self,
+        requested_predicate: &str,
+    ) -> Result<(String, CredentialAttributeValue)> {
         let (attribute, value) = self.get_case_insensitive_attribute(requested_predicate)?;
         match value {
-            CredentialAttributeValue::Predicate(value) => Ok((attribute, value)),
-            CredentialAttributeValue::Attribute(_) => Err(err_msg!(
-                "Credential predicate {} not found",
-                requested_predicate
-            )),
+            CredentialAttributeValue::Bool(_) => Ok((attribute, value)),
+            CredentialAttributeValue::String(_) | CredentialAttributeValue::Number(_) => Err(
+                err_msg!("Credential predicate {} not found", requested_predicate),
+            ),
         }
     }
 }

--- a/src/services/w3c/types.rs
+++ b/src/services/w3c/types.rs
@@ -8,7 +8,7 @@ impl MakeCredentialAttributes {
     pub fn add(&mut self, name: impl Into<String>, raw: impl Into<String>) {
         self.0
              .0
-            .insert(name.into(), CredentialAttributeValue::Attribute(raw.into()));
+            .insert(name.into(), CredentialAttributeValue::String(raw.into()));
     }
 }
 

--- a/src/services/w3c/verifier.rs
+++ b/src/services/w3c/verifier.rs
@@ -108,10 +108,13 @@ fn check_credential_restrictions(
             timestamp: None,
         };
         let filter = gather_filter_info(&identifier, schemas, cred_defs)?;
-        let mut attr_value_map: HashMap<String, Option<&str>> = HashMap::new();
+        let mut attr_value_map: HashMap<String, Option<String>> = HashMap::new();
         for (attribute, value) in credential.credential_subject.attributes.0.iter() {
-            if let CredentialAttributeValue::Attribute(value) = value {
-                attr_value_map.insert(attribute.to_owned(), Some(value));
+            if let CredentialAttributeValue::String(value) = value {
+                attr_value_map.insert(attribute.to_owned(), Some(value.to_string()));
+            }
+            if let CredentialAttributeValue::Number(value) = value {
+                attr_value_map.insert(attribute.to_owned(), Some(value.to_string()));
             }
         }
         process_operator(&attr_value_map, restrictions, &filter).map_err(err_map!(
@@ -194,7 +197,7 @@ fn check_requested_attribute<'a>(
                 .get(index)
                 .ok_or_else(|| err_msg!("Unable to get credential proof for index {}", index))?;
 
-            let encoded = encode_credential_attribute(&value)?;
+            let encoded = encode_credential_attribute(&value.to_string())?;
             if verify_revealed_attribute_value(&attribute, &proof.sub_proof, &encoded).is_err() {
                 continue;
             }
@@ -394,13 +397,13 @@ pub(crate) mod tests {
         CredentialAttributes(HashMap::from([
             (
                 "name".to_string(),
-                CredentialAttributeValue::Attribute("Alice".to_string()),
+                CredentialAttributeValue::String("Alice".to_string()),
             ),
             (
                 "height".to_string(),
-                CredentialAttributeValue::Attribute("178".to_string()),
+                CredentialAttributeValue::String("178".to_string()),
             ),
-            ("age".to_string(), CredentialAttributeValue::Predicate(true)),
+            ("age".to_string(), CredentialAttributeValue::Bool(true)),
         ]))
     }
 

--- a/tests/anoncreds_demos.rs
+++ b/tests/anoncreds_demos.rs
@@ -151,7 +151,9 @@ fn anoncreds_demo_works_for_single_issuer_single_prover(
         PresentedAttribute {
             referent: "attr1_referent",
             name: "name",
-            expected: ExpectedAttributeValue::RevealedAttribute("Alex"),
+            expected: ExpectedAttributeValue::RevealedAttribute(CredentialAttributeValue::String(
+                "Alex".to_string(),
+            )),
         },
     );
 
@@ -169,7 +171,9 @@ fn anoncreds_demo_works_for_single_issuer_single_prover(
         PresentedAttribute {
             referent: "attr3_referent",
             name: "name",
-            expected: ExpectedAttributeValue::GroupedAttribute("Alex"),
+            expected: ExpectedAttributeValue::GroupedAttribute(CredentialAttributeValue::String(
+                "Alex".to_string(),
+            )),
         },
     );
 
@@ -178,7 +182,9 @@ fn anoncreds_demo_works_for_single_issuer_single_prover(
         PresentedAttribute {
             referent: "attr3_referent",
             name: "height",
-            expected: ExpectedAttributeValue::GroupedAttribute("175"),
+            expected: ExpectedAttributeValue::GroupedAttribute(CredentialAttributeValue::Number(
+                175,
+            )),
         },
     );
 }
@@ -851,7 +857,9 @@ fn anoncreds_demo_works_for_requested_attribute_in_upper_case(
         PresentedAttribute {
             referent: "attr1_referent",
             name: "NAME",
-            expected: ExpectedAttributeValue::RevealedAttribute("Alex"),
+            expected: ExpectedAttributeValue::RevealedAttribute(CredentialAttributeValue::String(
+                "Alex".to_string(),
+            )),
         },
     );
 
@@ -869,7 +877,9 @@ fn anoncreds_demo_works_for_requested_attribute_in_upper_case(
         PresentedAttribute {
             referent: "attr3_referent",
             name: "NAME",
-            expected: ExpectedAttributeValue::GroupedAttribute("Alex"),
+            expected: ExpectedAttributeValue::GroupedAttribute(CredentialAttributeValue::String(
+                "Alex".to_string(),
+            )),
         },
     );
 
@@ -878,7 +888,9 @@ fn anoncreds_demo_works_for_requested_attribute_in_upper_case(
         PresentedAttribute {
             referent: "attr3_referent",
             name: "HEIGHT",
-            expected: ExpectedAttributeValue::GroupedAttribute("175"),
+            expected: ExpectedAttributeValue::GroupedAttribute(CredentialAttributeValue::Number(
+                175,
+            )),
         },
     );
 
@@ -2964,7 +2976,7 @@ fn anoncreds_demo_works_for_issue_legacy_credential_convert_into_w3c_and_present
     // Verifier verifies presentation
     let presentation = presentation.w3c();
     assert_eq!(
-        &CredentialAttributeValue::Attribute("Alex".to_string()),
+        &CredentialAttributeValue::String("Alex".to_string()),
         presentation.verifiable_credential[0]
             .credential_subject
             .attributes
@@ -2974,7 +2986,7 @@ fn anoncreds_demo_works_for_issue_legacy_credential_convert_into_w3c_and_present
     );
 
     assert_eq!(
-        CredentialAttributeValue::Predicate(true),
+        CredentialAttributeValue::Bool(true),
         presentation.verifiable_credential[0]
             .credential_subject
             .attributes
@@ -3283,7 +3295,7 @@ fn anoncreds_demo_works_for_issue_two_credentials_in_different_forms_and_present
     // Verifier verifies presentation
     let presentation = presentation.w3c();
     assert_eq!(
-        &CredentialAttributeValue::Attribute("Alex".to_string()),
+        &CredentialAttributeValue::String("Alex".to_string()),
         presentation.verifiable_credential[0]
             .credential_subject
             .attributes
@@ -3293,7 +3305,7 @@ fn anoncreds_demo_works_for_issue_two_credentials_in_different_forms_and_present
     );
 
     assert_eq!(
-        &CredentialAttributeValue::Attribute("male".to_string()),
+        &CredentialAttributeValue::String("male".to_string()),
         presentation.verifiable_credential[0]
             .credential_subject
             .attributes
@@ -3303,7 +3315,7 @@ fn anoncreds_demo_works_for_issue_two_credentials_in_different_forms_and_present
     );
 
     assert_eq!(
-        &CredentialAttributeValue::Attribute("Developer".to_string()),
+        &CredentialAttributeValue::String("Developer".to_string()),
         presentation.verifiable_credential[1]
             .credential_subject
             .attributes
@@ -3313,7 +3325,7 @@ fn anoncreds_demo_works_for_issue_two_credentials_in_different_forms_and_present
     );
 
     assert_eq!(
-        &CredentialAttributeValue::Attribute("IT".to_string()),
+        &CredentialAttributeValue::String("IT".to_string()),
         presentation.verifiable_credential[1]
             .credential_subject
             .attributes


### PR DESCRIPTION
Represent number credential values as `numbers` in W3C credential subject.
Current implementation similar to attributes encoding function. If a number can be parsed from raw value, put it as a number into a credential subject as well. 
Probably, in future, we better to change the function API to  accept some rich structure specifying value types along with values.  

Issue: https://github.com/hyperledger/anoncreds-rs/issues/297