### PR TITLE
chore: update version to 0.2.0-dev.7

### DIFF
--- a/Cargo.lock.android
+++ b/Cargo.lock.android
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "anoncreds"
-version = "0.2.0-dev.6"
+version = "0.2.0-dev.7"
 dependencies = [
  "anoncreds-clsignatures",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anoncreds"
-version = "0.2.0-dev.6"
+version = "0.2.0-dev.7"
 authors = [
     "Hyperledger AnonCreds Contributors <anoncreds@lists.hyperledger.org>",
 ]

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.2.0-dev.6",
+  "version": "0.2.0-dev.7",
   "npmClient": "pnpm",
   "command": {
     "version": {

--- a/wrappers/javascript/packages/anoncreds-nodejs/package.json
+++ b/wrappers/javascript/packages/anoncreds-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-nodejs",
-  "version": "0.2.0-dev.6",
+  "version": "0.2.0-dev.7",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Anoncreds",
   "main": "build/index",
@@ -43,7 +43,7 @@
   "binary": {
     "module_name": "anoncreds",
     "module_path": "native",
-    "remote_path": "v0.2.0-dev.6",
+    "remote_path": "v0.2.0-dev.7",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download/",
     "package_name": "library-{platform}-{arch}.tar.gz"
   }

--- a/wrappers/javascript/packages/anoncreds-react-native/package.json
+++ b/wrappers/javascript/packages/anoncreds-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-react-native",
-  "version": "0.2.0-dev.6",
+  "version": "0.2.0-dev.7",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Anoncreds",
   "main": "build/index",
@@ -51,7 +51,7 @@
   "binary": {
     "module_name": "anoncreds",
     "module_path": "native",
-    "remote_path": "v0.2.0-dev.6",
+    "remote_path": "v0.2.0-dev.7",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download/",
     "package_name": "library-ios-android.tar.gz"
   }

--- a/wrappers/javascript/packages/anoncreds-shared/package.json
+++ b/wrappers/javascript/packages/anoncreds-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-shared",
-  "version": "0.2.0-dev.6",
+  "version": "0.2.0-dev.7",
   "license": "Apache-2.0",
   "description": "Anoncreds wrapper library with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/python/anoncreds/version.py
+++ b/wrappers/python/anoncreds/version.py
@@ -1,3 +1,3 @@
 """anoncreds library wrapper version."""
 
-__version__ = "0.2.0-dev.6"
+__version__ = "0.2.0-dev.7"


### PR DESCRIPTION
To release latest PR to encode numbers as numbers, and the last release went wrong