### PR TITLE
refactor: only issuer id for legacy->w3c

### DIFF
--- a/Cargo.lock.android
+++ b/Cargo.lock.android
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "anoncreds"
-version = "0.2.0-dev.10"
+version = "0.2.0-dev.11"
 dependencies = [
  "anoncreds-clsignatures",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anoncreds"
-version = "0.2.0-dev.10"
+version = "0.2.0-dev.11"
 authors = [
     "Hyperledger AnonCreds Contributors <anoncreds@lists.hyperledger.org>",
 ]

--- a/src/ffi/w3c/credential.rs
+++ b/src/ffi/w3c/credential.rs
@@ -1,3 +1,4 @@
+use crate::data_types::issuer_id::IssuerId;
 use crate::data_types::w3c::VerifiableCredentialSpecVersion;
 use ffi_support::{rust_string_to_c, FfiStr};
 use std::ffi::c_char;
@@ -125,7 +126,7 @@ pub extern "C" fn anoncreds_process_w3c_credential(
 ///
 /// # Params
 /// cred:           object handle pointing to credential in legacy form to convert
-/// cred_def:       object handle pointing to the credential definition
+/// issuer_id:      issuer_id of the credential. Can be extracted from the cred_def and will be used as the `issuer` field in the w3c credential
 /// w3c_version:    version of w3c verifiable credential specification (1.1 or 2.0) to use
 /// cred_p:         reference that will contain converted credential (in W3C form) instance pointer
 ///
@@ -134,7 +135,7 @@ pub extern "C" fn anoncreds_process_w3c_credential(
 #[no_mangle]
 pub extern "C" fn anoncreds_credential_to_w3c(
     cred: ObjectHandle,
-    cred_def: ObjectHandle,
+    issuer_id: FfiStr,
     w3c_version: FfiStr,
     cred_p: *mut ObjectHandle,
 ) -> ErrorCode {
@@ -148,8 +149,8 @@ pub extern "C" fn anoncreds_credential_to_w3c(
             None => None,
         };
 
-        let w3c_credential =
-            credential_to_w3c(credential, cred_def.load()?.cast_ref()?, w3c_version)?;
+        let issuer_id = IssuerId::new(issuer_id).expect("Invalid issuer ID");
+        let w3c_credential = credential_to_w3c(credential, issuer_id, w3c_version)?;
         let w3c_cred = ObjectHandle::create(w3c_credential)?;
 
         unsafe { *cred_p = w3c_cred };

--- a/src/ffi/w3c/credential.rs
+++ b/src/ffi/w3c/credential.rs
@@ -150,7 +150,7 @@ pub extern "C" fn anoncreds_credential_to_w3c(
         };
 
         let issuer_id = IssuerId::new(issuer_id).expect("Invalid issuer ID");
-        let w3c_credential = credential_to_w3c(credential, issuer_id, w3c_version)?;
+        let w3c_credential = credential_to_w3c(credential, &issuer_id, w3c_version)?;
         let w3c_cred = ObjectHandle::create(w3c_credential)?;
 
         unsafe { *cred_p = w3c_cred };

--- a/src/ffi/w3c/credential.rs
+++ b/src/ffi/w3c/credential.rs
@@ -1,4 +1,3 @@
-use crate::data_types::issuer_id::IssuerId;
 use crate::data_types::w3c::VerifiableCredentialSpecVersion;
 use ffi_support::{rust_string_to_c, FfiStr};
 use std::ffi::c_char;
@@ -149,7 +148,10 @@ pub extern "C" fn anoncreds_credential_to_w3c(
             None => None,
         };
 
-        let issuer_id = IssuerId::new(issuer_id).expect("Invalid issuer ID");
+        let issuer_id = issuer_id
+            .as_opt_str()
+            .ok_or_else(|| err_msg!("Missing issuer id"))?
+            .try_into()?;
         let w3c_credential = credential_to_w3c(credential, &issuer_id, w3c_version)?;
         let w3c_cred = ObjectHandle::create(w3c_credential)?;
 

--- a/src/services/w3c/credential_conversion.rs
+++ b/src/services/w3c/credential_conversion.rs
@@ -81,13 +81,13 @@ use crate::Error;
 ///                            None,
 ///                            ).expect("Unable to process the credential");
 ///
-/// let _w3c_credential = w3c::credential_conversion::credential_to_w3c(&credential, &cred_def, None)
+/// let _w3c_credential = w3c::credential_conversion::credential_to_w3c(&credential, &cred_def.issuer_id, None)
 ///                         .expect("Unable to convert credential to w3c form");
 ///
 /// ```
 pub fn credential_to_w3c(
     credential: &Credential,
-    issuer_id: IssuerId,
+    issuer_id: &IssuerId,
     version: Option<VerifiableCredentialSpecVersion>,
 ) -> Result<W3CCredential, Error> {
     trace!(
@@ -228,7 +228,7 @@ pub fn credential_from_w3c(w3c_credential: &W3CCredential) -> Result<Credential,
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::data_types::cred_def::CredentialDefinitionId;
+    use crate::data_types::cred_def::{CredentialDefinition, CredentialDefinitionId};
     use crate::data_types::issuer_id::IssuerId;
     use crate::data_types::schema::{Schema, SchemaId};
     use crate::data_types::w3c::constants::ANONCREDS_CREDENTIAL_TYPES;
@@ -325,7 +325,7 @@ pub(crate) mod tests {
         let original_legacy_credential = legacy_credential();
         let w3c_credential = credential_to_w3c(
             &original_legacy_credential,
-            credential_definition().issuer_id,
+            &credential_definition().issuer_id,
             None,
         )
         .expect("unable to convert credential to w3c form");
@@ -344,7 +344,7 @@ pub(crate) mod tests {
         let legacy_credential = legacy_credential();
         let w3c_credential = credential_to_w3c(
             &legacy_credential,
-            credential_definition().issuer_id,
+            &credential_definition().issuer_id,
             Some(version),
         )
         .expect("unable to convert credential to w3c form");

--- a/src/services/w3c/credential_conversion.rs
+++ b/src/services/w3c/credential_conversion.rs
@@ -1,4 +1,4 @@
-use crate::data_types::cred_def::CredentialDefinition;
+use crate::data_types::issuer_id::IssuerId;
 use crate::data_types::w3c::credential::W3CCredential;
 use crate::data_types::w3c::credential_attributes::CredentialSubject;
 use crate::data_types::w3c::proof::{CredentialSignatureProofValue, DataIntegrityProof};
@@ -87,19 +87,19 @@ use crate::Error;
 /// ```
 pub fn credential_to_w3c(
     credential: &Credential,
-    cred_def: &CredentialDefinition,
+    issuer_id: IssuerId,
     version: Option<VerifiableCredentialSpecVersion>,
 ) -> Result<W3CCredential, Error> {
     trace!(
-        "credential_to_w3c >>> credential: {:?}, cred_def: {:?}",
+        "credential_to_w3c >>> credential: {:?}, issuer_id: {:?}",
         credential,
-        cred_def
+        issuer_id
     );
 
     credential.validate()?;
 
     let credential = credential.try_clone()?;
-    let issuer = cred_def.issuer_id.clone();
+    let issuer = issuer_id.clone();
     let attributes = CredentialSubject::from(&credential.values);
     let signature = CredentialSignatureProofValue {
         schema_id: credential.schema_id,
@@ -323,9 +323,12 @@ pub(crate) mod tests {
     #[test]
     fn test_convert_credential_to_and_from_w3c() {
         let original_legacy_credential = legacy_credential();
-        let w3c_credential =
-            credential_to_w3c(&original_legacy_credential, &credential_definition(), None)
-                .expect("unable to convert credential to w3c form");
+        let w3c_credential = credential_to_w3c(
+            &original_legacy_credential,
+            credential_definition().issuer_id,
+            None,
+        )
+        .expect("unable to convert credential to w3c form");
         let legacy_credential = credential_from_w3c(&w3c_credential)
             .expect("unable to convert credential to legacy form");
         assert_eq!(json!(original_legacy_credential), json!(legacy_credential),)
@@ -339,9 +342,12 @@ pub(crate) mod tests {
         #[case] expected_context: Contexts,
     ) {
         let legacy_credential = legacy_credential();
-        let w3c_credential =
-            credential_to_w3c(&legacy_credential, &credential_definition(), Some(version))
-                .expect("unable to convert credential to w3c form");
+        let w3c_credential = credential_to_w3c(
+            &legacy_credential,
+            credential_definition().issuer_id,
+            Some(version),
+        )
+        .expect("unable to convert credential to w3c form");
 
         assert_eq!(w3c_credential.context, expected_context.clone());
         assert_eq!(w3c_credential.type_, ANONCREDS_CREDENTIAL_TYPES.clone());

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -964,7 +964,7 @@ impl<'a> ProverWallet<'a> {
         match credential {
             Credentials::Legacy(legacy_cred) => {
                 // Convert legacy credential into W3C form
-                let w3c_cred = credential_to_w3c(&legacy_cred, cred_def.issuer_id, None)
+                let w3c_cred = credential_to_w3c(&legacy_cred, &cred_def.issuer_id, None)
                     .expect("Error converting legacy credential into W3C form");
 
                 // Store w3c credential in wallet

--- a/tests/utils/mock.rs
+++ b/tests/utils/mock.rs
@@ -964,7 +964,7 @@ impl<'a> ProverWallet<'a> {
         match credential {
             Credentials::Legacy(legacy_cred) => {
                 // Convert legacy credential into W3C form
-                let w3c_cred = credential_to_w3c(&legacy_cred, cred_def, None)
+                let w3c_cred = credential_to_w3c(&legacy_cred, cred_def.issuer_id, None)
                     .expect("Error converting legacy credential into W3C form");
 
                 // Store w3c credential in wallet

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.2.0-dev.10",
+  "version": "0.2.0-dev.11",
   "npmClient": "pnpm",
   "command": {
     "version": {

--- a/wrappers/javascript/packages/anoncreds-nodejs/package.json
+++ b/wrappers/javascript/packages/anoncreds-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-nodejs",
-  "version": "0.2.0-dev.10",
+  "version": "0.2.0-dev.11",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Anoncreds",
   "main": "build/index",
@@ -43,7 +43,7 @@
   "binary": {
     "module_name": "anoncreds",
     "module_path": "native",
-    "remote_path": "v0.2.0-dev.10",
+    "remote_path": "v0.2.0-dev.11",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download/",
     "package_name": "library-{platform}-{arch}.tar.gz"
   }

--- a/wrappers/javascript/packages/anoncreds-nodejs/src/NodeJSAnoncreds.ts
+++ b/wrappers/javascript/packages/anoncreds-nodejs/src/NodeJSAnoncreds.ts
@@ -656,16 +656,12 @@ export class NodeJSAnoncreds implements Anoncreds {
     return Boolean(handleReturnPointer<number>(ret))
   }
 
-  public credentialToW3c(options: {
-    objectHandle: ObjectHandle
-    credentialDefinition: ObjectHandle
-    w3cVersion?: string
-  }): ObjectHandle {
-    const { objectHandle, credentialDefinition, w3cVersion } = serializeArguments(options)
+  public credentialToW3c(options: { objectHandle: ObjectHandle; issuerId: string; w3cVersion?: string }): ObjectHandle {
+    const { objectHandle, issuerId, w3cVersion } = serializeArguments(options)
 
     const ret = allocatePointer()
 
-    this.nativeAnoncreds.anoncreds_credential_to_w3c(objectHandle, credentialDefinition, w3cVersion, ret)
+    this.nativeAnoncreds.anoncreds_credential_to_w3c(objectHandle, issuerId, w3cVersion, ret)
     this.handleError()
 
     return new ObjectHandle(handleReturnPointer<number>(ret))

--- a/wrappers/javascript/packages/anoncreds-nodejs/src/library/bindings.ts
+++ b/wrappers/javascript/packages/anoncreds-nodejs/src/library/bindings.ts
@@ -241,10 +241,7 @@ export const nativeBindings = {
       FFI_INT8_PTR
     ]
   ],
-  anoncreds_credential_to_w3c: [
-    FFI_ERRORCODE,
-    [FFI_OBJECT_HANDLE, FFI_OBJECT_HANDLE, FFI_STRING, FFI_OBJECT_HANDLE_PTR]
-  ],
+  anoncreds_credential_to_w3c: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, FFI_STRING, FFI_STRING, FFI_OBJECT_HANDLE_PTR]],
   anoncreds_credential_from_w3c: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, FFI_OBJECT_HANDLE_PTR]],
   anoncreds_w3c_credential_get_integrity_proof_details: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, FFI_OBJECT_HANDLE_PTR]],
   anoncreds_w3c_credential_proof_get_attribute: [FFI_ERRORCODE, [FFI_OBJECT_HANDLE, FFI_STRING, FFI_STRING_PTR]],

--- a/wrappers/javascript/packages/anoncreds-nodejs/tests/api.test.ts
+++ b/wrappers/javascript/packages/anoncreds-nodejs/tests/api.test.ts
@@ -647,11 +647,11 @@ describe('API W3C', () => {
     expect('mock:uri').toEqual(legacyCredentialFrom.schemaId)
     expect('mock:uri').toEqual(legacyCredentialFrom.credentialDefinitionId)
 
-    const w3cCredential = W3cCredential.fromLegacy({ credential: legacyCredential, credentialDefinition })
+    const w3cCredential = W3cCredential.fromLegacy({ credential: legacyCredential, issuerId: 'mock:uri' })
     expect('mock:uri').toEqual(w3cCredential.schemaId)
     expect('mock:uri').toEqual(w3cCredential.credentialDefinitionId)
 
-    const convertedW3cCredential = legacyCredential.toW3c({ credentialDefinition })
+    const convertedW3cCredential = legacyCredential.toW3c({ issuerId: 'mock:uri' })
     expect('mock:uri').toEqual(convertedW3cCredential.schemaId)
     expect('mock:uri').toEqual(convertedW3cCredential.credentialDefinitionId)
 

--- a/wrappers/javascript/packages/anoncreds-react-native/cpp/anoncreds.cpp
+++ b/wrappers/javascript/packages/anoncreds-react-native/cpp/anoncreds.cpp
@@ -870,15 +870,15 @@ jsi::Value processW3cCredential(jsi::Runtime &rt, jsi::Object options) {
 
 jsi::Value credentialToW3c(jsi::Runtime &rt, jsi::Object options) {
   auto credential = jsiToValue<ObjectHandle>(rt, options, "objectHandle");
-  auto credentialDefinition =
-      jsiToValue<ObjectHandle>(rt, options, "credentialDefinition");
+  auto issuerId =
+      jsiToValue<std::string>(rt, options, "issuerId");
   auto w3cVersion =
       jsiToValue<std::string>(rt, options, "w3cVersion", true);
 
   ObjectHandle out;
 
   ErrorCode code = anoncreds_credential_to_w3c(
-      credential, credentialDefinition,
+      credential, issuerId.c_str(),
       w3cVersion.length() ? w3cVersion.c_str() : nullptr, &out);
 
   return createReturnValue(rt, code, &out);

--- a/wrappers/javascript/packages/anoncreds-react-native/package.json
+++ b/wrappers/javascript/packages/anoncreds-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-react-native",
-  "version": "0.2.0-dev.10",
+  "version": "0.2.0-dev.11",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Anoncreds",
   "main": "build/index",
@@ -51,7 +51,7 @@
   "binary": {
     "module_name": "anoncreds",
     "module_path": "native",
-    "remote_path": "v0.2.0-dev.10",
+    "remote_path": "v0.2.0-dev.11",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download/",
     "package_name": "library-ios-android.tar.gz"
   }

--- a/wrappers/javascript/packages/anoncreds-react-native/src/NativeBindings.ts
+++ b/wrappers/javascript/packages/anoncreds-react-native/src/NativeBindings.ts
@@ -214,11 +214,7 @@ export type NativeBindings = {
 
   w3cCredentialProofGetAttribute(options: { objectHandle: number; name: string }): ReturnObject<string>
 
-  credentialToW3c(options: {
-    objectHandle: number
-    credentialDefinition: number
-    w3cVersion?: string
-  }): ReturnObject<Handle>
+  credentialToW3c(options: { objectHandle: number; issuerId: string; w3cVersion?: string }): ReturnObject<Handle>
 
   credentialFromW3c(options: { objectHandle: number }): ReturnObject<Handle>
 

--- a/wrappers/javascript/packages/anoncreds-react-native/src/ReactNativeAnoncreds.ts
+++ b/wrappers/javascript/packages/anoncreds-react-native/src/ReactNativeAnoncreds.ts
@@ -507,11 +507,7 @@ export class ReactNativeAnoncreds implements Anoncreds {
     return new ObjectHandle(handle)
   }
 
-  public credentialToW3c(options: {
-    objectHandle: ObjectHandle
-    credentialDefinition: ObjectHandle
-    w3cVersion?: string
-  }): ObjectHandle {
+  public credentialToW3c(options: { objectHandle: ObjectHandle; issuerId: string; w3cVersion?: string }): ObjectHandle {
     const handle = this.handleError(this.anoncreds.credentialToW3c(serializeArguments(options)))
     return new ObjectHandle(handle)
   }

--- a/wrappers/javascript/packages/anoncreds-shared/package.json
+++ b/wrappers/javascript/packages/anoncreds-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-shared",
-  "version": "0.2.0-dev.10",
+  "version": "0.2.0-dev.11",
   "license": "Apache-2.0",
   "description": "Anoncreds wrapper library with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/javascript/packages/anoncreds-shared/src/Anoncreds.ts
+++ b/wrappers/javascript/packages/anoncreds-shared/src/Anoncreds.ts
@@ -250,11 +250,7 @@ export type Anoncreds = {
 
   w3cCredentialFromJson(options: { json: string }): ObjectHandle
 
-  credentialToW3c(options: {
-    objectHandle: ObjectHandle
-    credentialDefinition: ObjectHandle
-    w3cVersion?: string
-  }): ObjectHandle
+  credentialToW3c(options: { objectHandle: ObjectHandle; issuerId: string; w3cVersion?: string }): ObjectHandle
 
   credentialFromW3c(options: { objectHandle: ObjectHandle }): ObjectHandle
 

--- a/wrappers/javascript/packages/anoncreds-shared/src/api/Credential.ts
+++ b/wrappers/javascript/packages/anoncreds-shared/src/api/Credential.ts
@@ -35,7 +35,7 @@ export type ProcessCredentialOptions = {
 }
 
 export type CredentialToW3cOptions = {
-  credentialDefinition: CredentialDefinition | JsonObject
+  issuerId: string
   w3cVersion?: string
 }
 
@@ -151,28 +151,13 @@ export class Credential extends AnoncredsObject {
   }
 
   public toW3c(options: CredentialToW3cOptions): W3cCredential {
-    let credential
-    // Objects created within this method must be freed up
-    const objectHandles: ObjectHandle[] = []
-    try {
-      const credentialDefinition =
-        options.credentialDefinition instanceof CredentialDefinition
-          ? options.credentialDefinition.handle
-          : pushToArray(CredentialDefinition.fromJson(options.credentialDefinition).handle, objectHandles)
-
-      credential = new W3cCredential(
-        anoncreds.credentialToW3c({
-          objectHandle: this.handle,
-          credentialDefinition,
-          w3cVersion: options.w3cVersion
-        }).handle
-      )
-    } finally {
-      objectHandles.forEach((handle) => {
-        handle.clear()
-      })
-    }
-    return credential
+    return new W3cCredential(
+      anoncreds.credentialToW3c({
+        objectHandle: this.handle,
+        issuerId: options.issuerId,
+        w3cVersion: options.w3cVersion
+      }).handle
+    )
   }
 
   public static fromW3c(options: CredentialFromW3cOptions) {

--- a/wrappers/javascript/packages/anoncreds-shared/src/api/W3cCredential.ts
+++ b/wrappers/javascript/packages/anoncreds-shared/src/api/W3cCredential.ts
@@ -36,7 +36,7 @@ export type ProcessW3cCredentialOptions = {
 
 export type W3cCredentialFromLegacyOptions = {
   credential: Credential
-  credentialDefinition: CredentialDefinition | JsonObject
+  issuerId: string
   w3cVersion?: string
 }
 
@@ -176,27 +176,12 @@ export class W3cCredential extends AnoncredsObject {
   }
 
   public static fromLegacy(options: W3cCredentialFromLegacyOptions): W3cCredential {
-    let credential
-    // Objects created within this method must be freed up
-    const objectHandles: ObjectHandle[] = []
-    try {
-      const credentialDefinition =
-        options.credentialDefinition instanceof CredentialDefinition
-          ? options.credentialDefinition.handle
-          : pushToArray(CredentialDefinition.fromJson(options.credentialDefinition).handle, objectHandles)
-
-      credential = new W3cCredential(
-        anoncreds.credentialToW3c({
-          objectHandle: options.credential.handle,
-          credentialDefinition,
-          w3cVersion: options.w3cVersion
-        }).handle
-      )
-    } finally {
-      objectHandles.forEach((handle) => {
-        handle.clear()
-      })
-    }
-    return credential
+    return new W3cCredential(
+      anoncreds.credentialToW3c({
+        objectHandle: options.credential.handle,
+        issuerId: options.issuerId,
+        w3cVersion: options.w3cVersion
+      }).handle
+    )
   }
 }

--- a/wrappers/python/anoncreds/bindings.py
+++ b/wrappers/python/anoncreds/bindings.py
@@ -1018,14 +1018,14 @@ def process_w3c_credential(
 
 def credential_to_w3c(
     cred: ObjectHandle,
-    cred_def: ObjectHandle,
+    issuer_id: str,
     w3c_version: Optional[str],
 ) -> ObjectHandle:
     result = ObjectHandle()
     do_call(
         "anoncreds_credential_to_w3c",
         cred,
-        cred_def,
+        encode_str(issuer_id),
         encode_str(w3c_version),
         byref(result),
     )

--- a/wrappers/python/anoncreds/types.py
+++ b/wrappers/python/anoncreds/types.py
@@ -345,15 +345,13 @@ class Credential(bindings.AnoncredsObject):
 
     def to_w3c(
         self,
-        cred_def: Union[str, CredentialDefinition],
+        issuer_id: str,
         w3c_version: Optional[str] = None,
     ) -> "W3cCredential":
-        if not isinstance(cred_def, bindings.AnoncredsObject):
-            cred_def = CredentialDefinition.load(cred_def)
         return W3cCredential(
             bindings.credential_to_w3c(
                 self.handle,
-                cred_def.handle,
+                issuer_id,
                 w3c_version
             )
         )
@@ -439,10 +437,10 @@ class W3cCredential(bindings.AnoncredsObject):
     def from_legacy(
         cls,
         cred: "Credential",
-        cred_def: Union[str, CredentialDefinition],
+        issuer_id: str,
         w3c_version: Optional[str] = None
     ) -> "W3cCredential":
-        return cred.to_w3c(cred_def, w3c_version)
+        return cred.to_w3c(issuer_id, w3c_version)
 
     def _get_proof_details(self) -> bindings.ObjectHandle:
         if self._proof_details is None:

--- a/wrappers/python/anoncreds/version.py
+++ b/wrappers/python/anoncreds/version.py
@@ -1,3 +1,3 @@
 """anoncreds library wrapper version."""
 
-__version__ = "0.2.0-dev.10"
+__version__ = "0.2.0-dev.11"

--- a/wrappers/python/demo/w3c_test.py
+++ b/wrappers/python/demo/w3c_test.py
@@ -91,11 +91,11 @@ legacy_cred = Credential.from_w3c(recv_cred)
 print("Legacy Credential `from_w3c`")
 print(legacy_cred.to_json())
 
-w3c_cred = legacy_cred.to_w3c(cred_def_pub)
+w3c_cred = legacy_cred.to_w3c(issuer_id)
 print("W3c converted Credential `to_w3c`")
 print(w3c_cred.to_json())
 
-w3c_cred_restored = W3cCredential.from_legacy(legacy_cred, cred_def_pub)
+w3c_cred_restored = W3cCredential.from_legacy(legacy_cred, issuer_id)
 print("W3C restored Credential `from_legacy`")
 print(w3c_cred_restored.to_json())
 


### PR DESCRIPTION
We were running into some issues when needing to transform between legacy -> w3c anoncreds as the method requires the cred_def to be passed. It seems the cred_def is only required for the issuer_id, and this PR updates it to only require a string issuer_id rather than the whole cred def. 

In our case we know the issuer_id, but we'd have to resolve the cred_def from the ledger

