### PR TITLE
Corrected building of W3C credential values passed through the FFI

### DIFF
--- a/src/services/w3c/types.rs
+++ b/src/services/w3c/types.rs
@@ -6,9 +6,14 @@ pub struct MakeCredentialAttributes(pub(crate) CredentialSubject);
 
 impl MakeCredentialAttributes {
     pub fn add(&mut self, name: impl Into<String>, raw: impl Into<String>) {
-        self.0
-             .0
-            .insert(name.into(), CredentialAttributeValue::String(raw.into()));
+        let string_value = raw.into();
+        let value = if let Ok(number) = string_value.parse::<i32>() {
+            CredentialAttributeValue::Number(number)
+        } else {
+            CredentialAttributeValue::String(string_value)
+        };
+
+        self.0 .0.insert(name.into(), value);
     }
 }
 

--- a/tests/anoncreds_demos.rs
+++ b/tests/anoncreds_demos.rs
@@ -4,7 +4,6 @@ use anoncreds::verifier;
 use rstest::rstest;
 use serde_json::json;
 use std::collections::{BTreeSet, HashMap};
-use anoncreds::w3c::credential_conversion::{credential_from_w3c, credential_to_w3c};
 
 use utils::*;
 
@@ -3043,15 +3042,7 @@ fn anoncreds_demo_works_for_issue_w3c_credential_convert_into_legacy_and_present
         None,
     );
 
-    println!("recv_cred {}", json!(recv_cred.w3c()).to_string());
-
     // Convert W3C credential into legacy form
-    let legacy_cred = credential_from_w3c(&recv_cred.w3c())
-        .expect("Error converting legacy credential into W3C form");
-    let w3c_cred = credential_to_w3c(&legacy_cred, &gvt_cred_def.issuer_id, None)
-        .expect("Error converting legacy credential into W3C form");
-    println!("w3c_cred {}", json!(w3c_cred).to_string());
-
     prover_wallet.convert_credential(GVT_CRED, &recv_cred, &gvt_cred_def);
 
     // Create and Verify legacy presentation using converted credential

--- a/tests/anoncreds_demos.rs
+++ b/tests/anoncreds_demos.rs
@@ -4,6 +4,7 @@ use anoncreds::verifier;
 use rstest::rstest;
 use serde_json::json;
 use std::collections::{BTreeSet, HashMap};
+use anoncreds::w3c::credential_conversion::{credential_from_w3c, credential_to_w3c};
 
 use utils::*;
 
@@ -3042,7 +3043,15 @@ fn anoncreds_demo_works_for_issue_w3c_credential_convert_into_legacy_and_present
         None,
     );
 
+    println!("recv_cred {}", json!(recv_cred.w3c()).to_string());
+
     // Convert W3C credential into legacy form
+    let legacy_cred = credential_from_w3c(&recv_cred.w3c())
+        .expect("Error converting legacy credential into W3C form");
+    let w3c_cred = credential_to_w3c(&legacy_cred, &gvt_cred_def.issuer_id, None)
+        .expect("Error converting legacy credential into W3C form");
+    println!("w3c_cred {}", json!(w3c_cred).to_string());
+
     prover_wallet.convert_credential(GVT_CRED, &recv_cred, &gvt_cred_def);
 
     // Create and Verify legacy presentation using converted credential


### PR DESCRIPTION
Related issue: https://github.com/hyperledger/anoncreds-rs/issues/321
