### PR TITLE
chore: update to stable 0.2.0

### DIFF
--- a/Cargo.lock.android
+++ b/Cargo.lock.android
@@ -34,7 +34,7 @@ dependencies = [
 
 [[package]]
 name = "anoncreds"
-version = "0.2.0-dev.11"
+version = "0.2.0"
 dependencies = [
  "anoncreds-clsignatures",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anoncreds"
-version = "0.2.0-dev.11"
+version = "0.2.0"
 authors = [
     "Hyperledger AnonCreds Contributors <anoncreds@lists.hyperledger.org>",
 ]

--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.2.0-dev.11",
+  "version": "0.2.0",
   "npmClient": "pnpm",
   "command": {
     "version": {

--- a/wrappers/javascript/packages/anoncreds-nodejs/package.json
+++ b/wrappers/javascript/packages/anoncreds-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-nodejs",
-  "version": "0.2.0-dev.11",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Anoncreds",
   "main": "build/index",
@@ -43,7 +43,7 @@
   "binary": {
     "module_name": "anoncreds",
     "module_path": "native",
-    "remote_path": "v0.2.0-dev.11",
+    "remote_path": "v0.2.0",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download/",
     "package_name": "library-{platform}-{arch}.tar.gz"
   }

--- a/wrappers/javascript/packages/anoncreds-react-native/package.json
+++ b/wrappers/javascript/packages/anoncreds-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-react-native",
-  "version": "0.2.0-dev.11",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Anoncreds",
   "main": "build/index",
@@ -51,7 +51,7 @@
   "binary": {
     "module_name": "anoncreds",
     "module_path": "native",
-    "remote_path": "v0.2.0-dev.11",
+    "remote_path": "v0.2.0",
     "host": "https://github.com/hyperledger/anoncreds-rs/releases/download/",
     "package_name": "library-ios-android.tar.gz"
   }

--- a/wrappers/javascript/packages/anoncreds-shared/package.json
+++ b/wrappers/javascript/packages/anoncreds-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-shared",
-  "version": "0.2.0-dev.11",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "description": "Anoncreds wrapper library with NodeJS and React Native",
   "main": "build/index",

--- a/wrappers/python/anoncreds/version.py
+++ b/wrappers/python/anoncreds/version.py
@@ -1,3 +1,3 @@
 """anoncreds library wrapper version."""
 
-__version__ = "0.2.0-dev.11"
+__version__ = "0.2.0"


### PR DESCRIPTION
We've verified everything to work correclty and would like to include AnonCreds 0.2.0 in the 0.5.0 release of Credo.

