### PR TITLE
chore: update version for js wrapper

### DIFF
--- a/wrappers/javascript/lerna.json
+++ b/wrappers/javascript/lerna.json
@@ -1,6 +1,6 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "npmClient": "pnpm",
   "command": {
     "version": {

--- a/wrappers/javascript/packages/anoncreds-nodejs/package.json
+++ b/wrappers/javascript/packages/anoncreds-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-nodejs",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "Nodejs wrapper for Anoncreds",
   "main": "build/index",

--- a/wrappers/javascript/packages/anoncreds-react-native/package.json
+++ b/wrappers/javascript/packages/anoncreds-react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-react-native",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "React Native wrapper for Anoncreds",
   "main": "build/index",

--- a/wrappers/javascript/packages/anoncreds-shared/package.json
+++ b/wrappers/javascript/packages/anoncreds-shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hyperledger/anoncreds-shared",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "description": "Anoncreds wrapper library with NodeJS and React Native",
   "main": "build/index",


### PR DESCRIPTION
Updating version to 0.2.1 after #327. Only for the JS wrapper, as I understand we follow the same strategy as in Askar and Indy VDR. I think @TimoGlastra in #296 did already the set-up so it will be just a matter of running the workflow manually.