### PR TITLE
fix(js): update ffi-napi

### DIFF
--- a/wrappers/javascript/packages/anoncreds-nodejs/package.json
+++ b/wrappers/javascript/packages/anoncreds-nodejs/package.json
@@ -27,7 +27,7 @@
     "install": "node scripts/install.js"
   },
   "dependencies": {
-    "@2060.io/ffi-napi": "4.0.8",
+    "@2060.io/ffi-napi": "4.0.9",
     "@2060.io/ref-napi": "3.0.6",
     "@hyperledger/anoncreds-shared": "workspace:*",
     "@mapbox/node-pre-gyp": "^1.0.11",

--- a/wrappers/javascript/packages/anoncreds-nodejs/package.json
+++ b/wrappers/javascript/packages/anoncreds-nodejs/package.json
@@ -27,8 +27,8 @@
     "install": "node scripts/install.js"
   },
   "dependencies": {
-    "@2060.io/ffi-napi": "4.0.9",
-    "@2060.io/ref-napi": "3.0.6",
+    "@2060.io/ffi-napi": "^4.0.9",
+    "@2060.io/ref-napi": "^3.0.6",
     "@hyperledger/anoncreds-shared": "workspace:*",
     "@mapbox/node-pre-gyp": "^1.0.11",
     "ref-array-di": "1.2.2",

--- a/wrappers/javascript/pnpm-lock.yaml
+++ b/wrappers/javascript/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
   packages/anoncreds-nodejs:
     dependencies:
       '@2060.io/ffi-napi':
-        specifier: 4.0.8
-        version: 4.0.8
+        specifier: 4.0.9
+        version: 4.0.9
       '@2060.io/ref-napi':
         specifier: 3.0.6
         version: 3.0.6
@@ -158,8 +158,8 @@ importers:
 
 packages:
 
-  /@2060.io/ffi-napi@4.0.8:
-    resolution: {integrity: sha512-sONRKLtxFKN5PXuZaa41b/kTN+R5qAh6PAL15/fnafnvAKQ5WBoxRIy8xRh8jo9mydywtt4IrWtatB93w0+3cA==}
+  /@2060.io/ffi-napi@4.0.9:
+    resolution: {integrity: sha512-JfVREbtkJhMXSUpya3JCzDumdjeZDCKv4PemiWK+pts5CYgdoMidxeySVlFeF5pHqbBpox4I0Be7sDwAq4N0VQ==}
     engines: {node: '>=18'}
     requiresBuild: true
     dependencies:

--- a/wrappers/javascript/pnpm-lock.yaml
+++ b/wrappers/javascript/pnpm-lock.yaml
@@ -66,10 +66,10 @@ importers:
   packages/anoncreds-nodejs:
     dependencies:
       '@2060.io/ffi-napi':
-        specifier: 4.0.9
+        specifier: ^4.0.9
         version: 4.0.9
       '@2060.io/ref-napi':
-        specifier: 3.0.6
+        specifier: ^3.0.6
         version: 3.0.6
       '@hyperledger/anoncreds-shared':
         specifier: workspace:*


### PR DESCRIPTION
Updated `ffi-napi` dependency on JS wrapper in order to fix the incompatibility issue found with newer node.js versions. See https://github.com/nodejs/node/issues/52240#issuecomment-2040598178.