### PR TITLE
style: adapt to rustfmt 1.6.0 rules

### DIFF
--- a/src/data_types/w3c/format.rs
+++ b/src/data_types/w3c/format.rs
@@ -37,12 +37,15 @@ pub mod base64_msgpack {
             where
                 E: serde::de::Error,
             {
-                let Some(obj) = v.strip_prefix(BASE_HEADER).and_then(|v| {
-                    base64::decode(v).ok()
-                }).and_then(|v| {
-                    msg_pack::decode(&v).ok()
-                }) else {
-                    return Err(E::custom(format!("Unexpected multibase base header: {:?}", v)))
+                let Some(obj) = v
+                    .strip_prefix(BASE_HEADER)
+                    .and_then(|v| base64::decode(v).ok())
+                    .and_then(|v| msg_pack::decode(&v).ok())
+                else {
+                    return Err(E::custom(format!(
+                        "Unexpected multibase base header: {:?}",
+                        v
+                    )));
                 };
                 Ok(obj)
             }

--- a/src/data_types/w3c/proof.rs
+++ b/src/data_types/w3c/proof.rs
@@ -77,7 +77,7 @@ impl<'de> Deserialize<'de> for DataIntegrityProofValue {
                 A: serde::de::SeqAccess<'de>,
             {
                 let Some(key) = map.next_element()? else {
-                    return Err(A::Error::custom("expected tagged DataIntegrityProof"))
+                    return Err(A::Error::custom("expected tagged DataIntegrityProof"));
                 };
                 let mut result = match key {
                     1i32 => map

--- a/src/services/w3c/verifier.rs
+++ b/src/services/w3c/verifier.rs
@@ -376,7 +376,8 @@ fn check_request_data(
         .iter()
         .zip(credential_proofs)
     {
-        let Some(cred_def_issuer) = cred_defs.get(&proof.cred_def_id).map(|cd| &cd.issuer_id) else {
+        let Some(cred_def_issuer) = cred_defs.get(&proof.cred_def_id).map(|cd| &cd.issuer_id)
+        else {
             return Err(err_msg!("Missing credential definition"));
         };
         if cred_def_issuer != &cred.issuer {


### PR DESCRIPTION
After checking the issue found in https://github.com/hyperledger/anoncreds-rs/pull/331 I thought: "why just don't make rustfmt happy?". So I simply ran the formatter using the version we are using in the CI.