### PR TITLE
fix: add support to compile in react native 0.76 (new architecture)

### DIFF
--- a/wrappers/javascript/packages/anoncreds-react-native/android/CMakeLists.txt
+++ b/wrappers/javascript/packages/anoncreds-react-native/android/CMakeLists.txt
@@ -87,7 +87,14 @@ if(${REACT_NATIVE_VERSION} LESS 71)
   )
 endif()
 
-if(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
+if(${REACT_NATIVE_VERSION} GREATER_EQUAL 76)
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ReactAndroid::jsi
+    ReactAndroid::reactnative
+    fbjni::fbjni
+  )
+elseif(${REACT_NATIVE_VERSION} GREATER_EQUAL 71)
   target_link_libraries(
     ${PACKAGE_NAME}
     ReactAndroid::jsi


### PR DESCRIPTION
Hi hyperledger. I hope everything is doing well. We are currently using this repo in react-native app and we are updating to react native 0.76 (new architecture) and We faced a problem to compile in this new version. So, to solve this situation We rely on projects such as https://github.com/mrousavy/react-native-vision-camera and others that used same solution

To help I let you their PR where They added those changes to support it
https://github.com/mrousavy/react-native-vision-camera/pull/3263/files

After add that changes we could compile app in this new version
Regards!

