### PR TITLE
chore: v0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "anoncreds"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
     "Hyperledger AnonCreds Contributors <anoncreds@lists.hyperledger.org>",
 ]

--- a/wrappers/python/anoncreds/version.py
+++ b/wrappers/python/anoncreds/version.py
@@ -1,3 +1,3 @@
 """anoncreds library wrapper version."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"


### PR DESCRIPTION
Just a version bump prior to triggering a new release. Although we still have the issue of creating Python wrapper (#365), I think we can create a new release to publish mobile binaries required by JavaScript wrapper.